### PR TITLE
go: fix Check() when only separator is present in code

### DIFF
--- a/go/olc.go
+++ b/go/olc.go
@@ -122,6 +122,10 @@ func Check(code string) error {
 			return errors.New("odd number of padding chars")
 		}
 	}
+	if n == 1 {
+		return errors.New("only separator present in code")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This ports the fix from the javascript implementation at
7791bb5dce1715893ecd2a96022c2b34217e8a6f