### PR TITLE
Add Ruby gemspec file

### DIFF
--- a/ruby/open-location-code.gemspec
+++ b/ruby/open-location-code.gemspec
@@ -1,0 +1,26 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "date"
+
+Gem::Specification.new do |s|
+  s.name          = "open-location-code"
+  s.version       = "0.0.1"
+  s.authors       = ["Wei-Ming Wu"]
+  s.date          = Date.today.to_s
+  s.email         = ["wnameless@gmail.com"]
+  s.summary       = %q{Ruby implementation of Google Open Location Code(Plus+Codes)}
+  s.description   = s.summary
+  s.homepage      = "https://github.com/google/open-location-code"
+  s.license       = "Apache License, Version 2.0"
+
+  s.files         = Dir["lib/**/*"]
+  s.test_files    = Dir["test/**/*"]
+  s.require_paths = ["lib"]
+
+  s.add_development_dependency "bundler", "~> 1.7"
+  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "test-unit"
+  s.add_development_dependency "simplecov"
+  s.add_development_dependency "yard"
+end


### PR DESCRIPTION
I added gemspec file for publishing @wnameless 's ruby implementation to rubygems.org.

wnameless has already published https://github.com/wnameless/plus_codes-ruby gem, however, I prefer publishing gem from this official repository to wnameless's third-party repository. Because it makes easier for us to maintain codes, for users to find out this library.

@drinckes @wnameless How do you think about that?

I already signed the Contributor License Agreements.