### PR TITLE
Fix VBA test message

### DIFF
--- a/visualbasic/OpenLocationCode.bas
+++ b/visualbasic/OpenLocationCode.bas
@@ -598,7 +598,7 @@ Sub TestOLCLibrary()
       Exit Sub
     End If
     If f <> (validity(i)(3) = "true") Then
-      MsgBox ("IsFull test " + CStr(i) + ", expected: " + CStr(validity(i)(2) = "true") + ", actual: " + CStr(f))
+      MsgBox ("IsFull test " + CStr(i) + ", expected: " + CStr(validity(i)(3) = "true") + ", actual: " + CStr(f))
       Exit Sub
     End If
   Next


### PR DESCRIPTION
Fix typo in one of the error messages in the test section. This doesn't affect operation of the library. See issue #66.