### PR TITLE
declare exception throwing in constructor

### DIFF
--- a/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/com/google/openlocationcode/OpenLocationCode.java
@@ -152,8 +152,7 @@ public final class OpenLocationCode {
    * @throws IlegalArgumentException when the passed code is not valid.
    * @constructor
   */
-  public OpenLocationCode(String code)
-      throws IllegalArgumentException {
+  public OpenLocationCode(String code) throws IllegalArgumentException {
     if (!isValidCode(code.toUpperCase())) {
       throw new IllegalArgumentException(
           "The provided code '" + code + "' is not a valid Open Location Code.");

--- a/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/com/google/openlocationcode/OpenLocationCode.java
@@ -152,7 +152,8 @@ public final class OpenLocationCode {
    * @throws IlegalArgumentException when the passed code is not valid.
    * @constructor
   */
-  public OpenLocationCode(String code) {
+  public OpenLocationCode(String code)
+      throws IllegalArgumentException {
     if (!isValidCode(code.toUpperCase())) {
       throw new IllegalArgumentException(
           "The provided code '" + code + "' is not a valid Open Location Code.");


### PR DESCRIPTION
Both constructors claim that they might throw an IllegalArgumentException via comment, but only one of them actually declares as much. Add "throws" clause to other constructor for consistency.