### PR TITLE
Changes to Rust implementation

### DIFF
--- a/rust/src/interface.rs
+++ b/rust/src/interface.rs
@@ -109,13 +109,13 @@ pub fn encode(pt: Point<f64>, code_length: usize) -> String {
     // Latitude 90 needs to be adjusted to be just less, so the returned code
     // can also be decoded.
     if lat > LATITUDE_MAX || (LATITUDE_MAX - lat) < 1e-10f64 {
-        lat = lat - compute_latitude_precision(code_length);
+        lat -= compute_latitude_precision(code_length);
     }
 
     lat += LATITUDE_MAX;
     lng += LONGITUDE_MAX;
 
-    let mut code = String::new();
+    let mut code = String::with_capacity(code_length + 1);
     let mut digit = 0;
     while digit < code_length {
         narrow_region(digit, &mut lat, &mut lng);
@@ -130,8 +130,8 @@ pub fn encode(pt: Point<f64>, code_length: usize) -> String {
             code.push(CODE_ALPHABET[4 * lat_digit + lng_digit]);
             digit += 1;
         }
-        lat = lat - lat_digit as f64;
-        lng = lng - lng_digit as f64;
+        lat -= lat_digit as f64;
+        lng -= lng_digit as f64;
         if digit == SEPARATOR_POSITION {
             code.push(SEPARATOR);
         }

--- a/rust/src/private.rs
+++ b/rust/src/private.rs
@@ -8,26 +8,19 @@ use interface::encode;
 use geo::Point;
 
 pub fn code_value(chr: char) -> usize {
-    for (i, c) in CODE_ALPHABET.iter().enumerate() {
-        if chr == *c {
-            return i;
-        }
-    }
     // We assume this function is only called by other functions that have
     // already ensured that the characters in the passed-in code are all valid
     // and have all been "treated" (upper-cased, padding and '+' stripped)
-    //
-    // If that is the case, we will always return above.
-    unreachable!();
+    CODE_ALPHABET.iter().position(|&x| x == char).unwrap()
 }
 
 pub fn normalize_longitude(value: f64) -> f64 {
     let mut result: f64 = value;
     while result >= LONGITUDE_MAX {
-        result = result - LONGITUDE_MAX * 2f64;
+        result -= LONGITUDE_MAX * 2f64;
     }
     while result < -LONGITUDE_MAX{
-        result = result + LONGITUDE_MAX * 2f64;
+        result += LONGITUDE_MAX * 2f64;
     }
     result
 }
@@ -40,7 +33,7 @@ pub fn compute_latitude_precision(code_length: usize) -> f64 {
     if code_length <= PAIR_CODE_LENGTH {
         return ENCODING_BASE.powf((code_length as f64 / -2f64 + 2f64).floor())
     }
-    ENCODING_BASE.powf(-3f64) / GRID_ROWS.powf(code_length as f64 - PAIR_CODE_LENGTH as f64)
+    ENCODING_BASE.powi(-3f64) / GRID_ROWS.powf(code_length as f64 - PAIR_CODE_LENGTH as f64)
 }
 
 pub fn prefix_by_reference(pt: Point<f64>, code_length: usize) -> String {

--- a/rust/src/private.rs
+++ b/rust/src/private.rs
@@ -33,7 +33,7 @@ pub fn compute_latitude_precision(code_length: usize) -> f64 {
     if code_length <= PAIR_CODE_LENGTH {
         return ENCODING_BASE.powf((code_length as f64 / -2f64 + 2f64).floor())
     }
-    ENCODING_BASE.powi(-3f64) / GRID_ROWS.powf(code_length as f64 - PAIR_CODE_LENGTH as f64)
+    ENCODING_BASE.powi(-3i32) / GRID_ROWS.powf(code_length as f64 - PAIR_CODE_LENGTH as f64)
 }
 
 pub fn prefix_by_reference(pt: Point<f64>, code_length: usize) -> String {


### PR DESCRIPTION
* Use `position()` on `iter()` instead of loop in `code_value`
* Use arithmetic operator in `normalize_longitude`
* Use `powi` for integer power (`-3`) in `compute_latitude_precision`
* Use arithmetic operators in `encode`
* Reserve String space (`/cpp/openlocationcode.cc`) in `encode`