### PR TITLE
Fix #89 for C++, add further tests

### DIFF
--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -328,7 +328,7 @@ std::string RecoverNearest(const std::string &short_code,
   // within -90 to 90 degrees.
   double center_lat = code_rect.GetCenter().latitude;
   double center_lng = code_rect.GetCenter().longitude;
-  if (latitude + half_res < center_lat && center_lat - resolution > internal::kLatitudeMaxDegrees) {
+  if (latitude + half_res < center_lat && center_lat - resolution > -internal::kLatitudeMaxDegrees) {
     // If the proposed code is more than half a cell north of the reference location,
     // it's too far, and the best match will be one cell south.
     center_lat -= resolution;

--- a/test_data/shortCodeTests.csv
+++ b/test_data/shortCodeTests.csv
@@ -17,8 +17,14 @@
 # Added to detect error in recoverNearest functionality
 8FJFW222+,42.899,9.012,22+,B
 796RXG22+,14.95125,-23.5001,22+,B
-# Added to detect error in recoverNearest - latitude needs south adjustment
-8FRCXGRF+PM,47.00,8.55,XGRF+PM,B
+# Reference location is in the 4 digit cell to the south.
+8FVC2GGG+GG,46.976,8.526,2GGG+GG,B
+# Reference location is in the 4 digit cell to the north.
+8FRCXGGG+GG,47.026,8.526,XGGG+GG,B
+# Reference location is in the 4 digit cell to the east.
+8FR9GXGG+GG,46.526,8.026,GXGG+GG,B
+# Reference location is in the 4 digit cell to the west.
+8FRCG2GG+GG,46.526,7.976,B
 # Added to detect errors recovering codes near the poles.
 # This tests recovery function, but these codes won't shorten.
 CFX22222+22,89.6,0.0,2222+22,R

--- a/test_data/shortCodeTests.csv
+++ b/test_data/shortCodeTests.csv
@@ -24,7 +24,7 @@
 # Reference location is in the 4 digit cell to the east.
 8FR9GXGG+GG,46.526,8.026,GXGG+GG,B
 # Reference location is in the 4 digit cell to the west.
-8FRCG2GG+GG,46.526,7.976,B
+8FRCG2GG+GG,46.526,7.976,G2GG+GG,B
 # Added to detect errors recovering codes near the poles.
 # This tests recovery function, but these codes won't shorten.
 CFX22222+22,89.6,0.0,2222+22,R

--- a/test_data/shortCodeTests.csv
+++ b/test_data/shortCodeTests.csv
@@ -17,6 +17,8 @@
 # Added to detect error in recoverNearest functionality
 8FJFW222+,42.899,9.012,22+,B
 796RXG22+,14.95125,-23.5001,22+,B
+# Added to detect error in recoverNearest - latitude needs south adjustment
+8FRCXGRF+PM,47.00,8.55,XGRF+PM
 # Added to detect errors recovering codes near the poles.
 # This tests recovery function, but these codes won't shorten.
 CFX22222+22,89.6,0.0,2222+22,R

--- a/test_data/shortCodeTests.csv
+++ b/test_data/shortCodeTests.csv
@@ -18,7 +18,7 @@
 8FJFW222+,42.899,9.012,22+,B
 796RXG22+,14.95125,-23.5001,22+,B
 # Added to detect error in recoverNearest - latitude needs south adjustment
-8FRCXGRF+PM,47.00,8.55,XGRF+PM
+8FRCXGRF+PM,47.00,8.55,XGRF+PM,B
 # Added to detect errors recovering codes near the poles.
 # This tests recovery function, but these codes won't shorten.
 CFX22222+22,89.6,0.0,2222+22,R


### PR DESCRIPTION
There was a typo in the C++ fix for #89 but it wasn't exercised by any tests.
This adds tests for codes with reference locations in the neighbouring 4-digit cell and confirms they shorten and recover correctly.