### PR TITLE
Fix cpp argument naming and usage.

### DIFF
--- a/cpp/openlocationcode.h
+++ b/cpp/openlocationcode.h
@@ -54,7 +54,8 @@ std::string Shorten(const std::string &code, const LatLng &reference_location);
 //
 // If the code isn't a valid short code, it cannot be recovered and the code
 // is returned as-is.
-std::string RecoverNearest(const std::string &short_code, const LatLng &location);
+std::string RecoverNearest(const std::string &short_code,
+                           const LatLng &reference_location);
 
 // Returns the number of valid Open Location Code characters in a string. This
 // excludes invalid characters and separators.

--- a/cpp/openlocationcode_test.cc
+++ b/cpp/openlocationcode_test.cc
@@ -37,7 +37,8 @@ TEST(ParameterChecks, ShortenDegreesValid) {
 
 namespace {
 
-std::vector<std::vector<std::string>> ParseCsv(std::string path_to_file) {
+std::vector<std::vector<std::string>> ParseCsv(
+    const std::string& path_to_file) {
   std::vector<std::vector<std::string>> csv_records;
   std::string line;
 


### PR DESCRIPTION
Make argument name in .h the same as .cc, and change an arg to a const in the test code.