### PR TITLE
Speed: Negate value instead of calling fabs

### DIFF
--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -42,7 +42,7 @@ double pow_neg(double base, double exponent) {
   } else if (exponent > 0) {
     return pow(base, exponent);
   }
-  return 1 / pow(base, fabs(exponent));
+  return 1 / pow(base, -exponent);
 }
 
 // Compute the latitude precision value for a given code length. Lengths <= 10


### PR DESCRIPTION
Marginal speed improvement by negating a value that is known to be negative rather than calling fabs(), which can be slow in certain build situations.