### PR TITLE
Use fine-grained closure_js_library deps

### DIFF
--- a/js/closure/BUILD
+++ b/js/closure/BUILD
@@ -3,24 +3,22 @@ load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library", "closure
 closure_js_library(
     name = "openlocationcode_lib",
     srcs = ["openlocationcode.js"],
-    deps = [
-        "@io_bazel_rules_closure//closure/library",
-    ],
 )
 
 closure_js_test(
     name = "openlocationcode_test",
     timeout = "short",
     srcs = ["openlocationcode_test.js"],
-    entry_points = ["goog:openlocationcode_test"],
     data = [
         "//test_data",
     ],
+    entry_points = ["goog:openlocationcode_test"],
     deps = [
         ":openlocationcode_lib",
         "@io_bazel_rules_closure//closure/library/net:eventtype",
         "@io_bazel_rules_closure//closure/library/net:xhrio",
+        "@io_bazel_rules_closure//closure/library/testing:asserts",
         "@io_bazel_rules_closure//closure/library/testing:asynctestcase",
-        "@io_bazel_rules_closure//closure/library:testing",
+        "@io_bazel_rules_closure//closure/library/testing:testsuite",
     ],
 )


### PR DESCRIPTION
This way the Closure Compiler needs to be run 693 fewer times.

    $ bazel query 'kind(closure_js_library, deps(//js/closure/...))' | wc -l
    802  # <-- before
    109  # <-- after

Notes:

1. These build rules export the world, for the sake of convenience:
    - `@io_bazel_rules_closure//closure/library`
    - `@io_bazel_rules_closure//closure/library:testing`
2. closure_js_library has an implicit dependency on base.js.
3. rules_closure runs jscomp on each closure_js_library.