### PR TITLE
Remove use of std::begin() and std::end()

### DIFF
--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -405,11 +405,10 @@ bool IsValid(const std::string &code) {
     return false;
   }
   // Are there any invalid characters?
+  const char* end = internal::kAlphabet + internal::kEncodingBase;
   for (char c : code) {
     if (c != internal::kSeparator && c != internal::kPaddingCharacter &&
-        std::find(std::begin(internal::kAlphabet),
-                  std::end(internal::kAlphabet),
-                  (char)toupper(c)) == std::end(internal::kAlphabet)) {
+        std::find(internal::kAlphabet, end, (char)toupper(c)) == end) {
       return false;
     }
   }


### PR DESCRIPTION
Remove single use of std::begin() and std::end() on a const char array. std::end() is actually incorrect for this use since it returns the end location AFTER the terminating null character so std::find() would match any null character in the string (although there are none). Replace std::end() with internal::kAlphabet + internal::kEncodingBase, consistent with a very similar std::find() search earlier in the code.