### PR TITLE
Optimize get_alphabet_position()

### DIFF
--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -13,6 +13,10 @@ const size_t kSeparatorPosition = 8;
 const size_t kMaximumDigitCount = 32;
 const char kPaddingCharacter = '0';
 const char kAlphabet[] = "23456789CFGHJMPQRVWX";
+// Lookup table of the alphabet positions of characters 'C' through 'X',
+// inclusive. A value of -1 means the character isn't part of the alphabet.
+const int kPositionLUT['X' - 'C' + 1] = { 8, -1, -1, 9, 10, 11, -1, 12, -1, -1,
+    13, -1, -1, 14, 15, 16, -1, -1, -1, 17, 18, 19 };
 const size_t kEncodingBase = 20;
 const size_t kPairCodeLength = 10;
 const size_t kGridColumns = 4;
@@ -56,11 +60,9 @@ double compute_precision_for_length(int code_length) {
 
 // Returns the position of a char in the encoding alphabet, or -1 if invalid.
 int get_alphabet_position(char c) {
-  // Lookup table of alphabet positions of characters 'C' through 'X'.
-  static const int kPositionLUT['X' - 'C' + 1] = { 8, -1, -1, 9, 10, 11, -1, 12,
-      -1, -1, 13, -1, -1, 14, 15, 16, -1, -1, -1, 17, 18, 19 };
-  if (c >= 'C' && c <= 'X') return kPositionLUT[c - 'C'];
-  if (c >= 'c' && c <= 'x') return kPositionLUT[c - 'c'];
+  // We use a lookup table for performance reasons (e.g. over std::find).
+  if (c >= 'C' && c <= 'X') return internal::kPositionLUT[c - 'C'];
+  if (c >= 'c' && c <= 'x') return internal::kPositionLUT[c - 'c'];
   if (c >= '2' && c <= '9') return c - '2';
   return -1;
 }

--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -59,9 +59,10 @@ int get_alphabet_position(char c) {
   // Lookup table of alphabet positions of characters 'C' through 'X'.
   static const int kPositionLUT['X' - 'C' + 1] = { 8, -1, -1, 9, 10, 11, -1, 12,
       -1, -1, 13, -1, -1, 14, 15, 16, -1, -1, -1, 17, 18, 19 };
-  if (c >= '2' && c <= '9') return c - '2';
   if (c >= 'C' && c <= 'X') return kPositionLUT[c - 'C'];
-  return (c >= 'c' && c <= 'x') ? kPositionLUT[c - 'c'] : -1;
+  if (c >= 'c' && c <= 'x') return kPositionLUT[c - 'c'];
+  if (c >= '2' && c <= '9') return c - '2';
+  return -1;
 }
 
 // Normalize a longitude into the range -180 to 180, not including 180.

--- a/cpp/openlocationcode.h
+++ b/cpp/openlocationcode.h
@@ -90,6 +90,9 @@ extern const size_t kMaximumDigitCount;
 extern const char kPaddingCharacter;
 // The alphabet of the codes.
 extern const char kAlphabet[];
+// Lookup table of the alphabet positions of characters 'C' through 'X',
+// inclusive. A value of -1 means the character isn't part of the alphabet.
+extern const int kPositionLUT['X' - 'C' + 1];
 // The number base used for the encoding.
 extern const size_t kEncodingBase;
 // How many characters use the pair algorithm.

--- a/cpp/openlocationcode_test.cc
+++ b/cpp/openlocationcode_test.cc
@@ -1,5 +1,6 @@
 #include "openlocationcode.h"
 
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <fstream>

--- a/cpp/openlocationcode_test.cc
+++ b/cpp/openlocationcode_test.cc
@@ -1,6 +1,6 @@
 #include "openlocationcode.h"
 
-#include <algorithm>
+#include <cstring>
 #include <stdio.h>
 #include <stdlib.h>
 #include <fstream>
@@ -38,8 +38,7 @@ TEST(ParameterChecks, PositionLUTMatchesAlphabet) {
       EXPECT_EQ(c, internal::kAlphabet[pos]);
     } else {
       // Otherwise, verify this character is not in kAlphabet.
-      const char* end = internal::kAlphabet + internal::kEncodingBase;
-      EXPECT_EQ(std::find(internal::kAlphabet, end, c), end);
+      EXPECT_EQ(std::strchr(internal::kAlphabet, c), nullptr);
     }
   }
 }

--- a/cpp/openlocationcode_test.cc
+++ b/cpp/openlocationcode_test.cc
@@ -24,6 +24,25 @@ TEST(ParameterChecks, AlphabetIsOrdered) {
   }
 }
 
+TEST(ParameterChecks, PositionLUTMatchesAlphabet) {
+  // Loop over all elements of the lookup table.
+  for (size_t i = 0;
+       i < sizeof(internal::kPositionLUT) / sizeof(internal::kPositionLUT[0]);
+       ++i) {
+    const int pos = internal::kPositionLUT[i];
+    const char c = 'C' + i;
+    if (pos != -1) {
+      // If the LUT entry indicates this character is in kAlphabet, verify it.
+      EXPECT_LT(pos, internal::kEncodingBase);
+      EXPECT_EQ(c, internal::kAlphabet[pos]);
+    } else {
+      // Otherwise, verify this character is not in kAlphabet.
+      const char* end = internal::kAlphabet + internal::kEncodingBase;
+      EXPECT_EQ(std::find(internal::kAlphabet, end, c), end);
+    }
+  }
+}
+
 TEST(ParameterChecks, SeparatorPositionValid) {
   EXPECT_TRUE(internal::kSeparatorPosition <= internal::kPairCodeLength);
 }


### PR DESCRIPTION
Improve get_alphabet_position() by using a lookup table to streamline performance, and have it also accept lowercase characters, obviating the use of ctype.h::toupper(). (Also eliminates dependency on std::find().)

TESTED=Passes all tests.