### PR TITLE
Fix obsolete structure init in CodeArea::GetCenter()

### DIFF
--- a/cpp/codearea.cc
+++ b/cpp/codearea.cc
@@ -35,9 +35,12 @@ double CodeArea::GetLongitudeHi() const {
 size_t CodeArea::GetCodeLength() const { return code_length_; }
 
 LatLng CodeArea::GetCenter() const {
-  double latitude_center = std::min(latitude_lo_ + (latitude_hi_ - latitude_lo_) / 2, kLatitudeMaxDegrees);
-  double longitude_center = std::min(longitude_lo_ + (longitude_hi_ - longitude_lo_) / 2, kLongitudeMaxDegrees);
-  LatLng center = {latitude: latitude_center, longitude: longitude_center};
+  const double latitude_center = std::min(
+      latitude_lo_ + (latitude_hi_ - latitude_lo_) / 2, kLatitudeMaxDegrees);
+  const double longitude_center =
+      std::min(longitude_lo_ + (longitude_hi_ - longitude_lo_) / 2,
+               kLongitudeMaxDegrees);
+  const LatLng center = {latitude_center, longitude_center};
   return center;
 }
 


### PR DESCRIPTION
Fix structure initialization syntax which is non-standard and "obsolete since GCC 2.5" (https://gcc.gnu.org/onlinedocs/gcc-4.8.1/gcc/Designated-Inits.html). Just use the C99 style, as anything else doesn't work with even recent Microsoft compilers.

Also tidy up the formatting in the rest of the function.

TESTED=all tests pass