### PR TITLE
Change equals() to directly check code equality in Java library.

### DIFF
--- a/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
@@ -15,6 +15,7 @@
 package com.google.openlocationcode;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 /**
  * Convert locations to and from convenient short codes.
@@ -472,7 +473,7 @@ public final class OpenLocationCode {
       return false;
     }
     OpenLocationCode that = (OpenLocationCode) o;
-    return hashCode() == that.hashCode();
+    return Objects.equals(code, that.code);
   }
 
   @Override


### PR DESCRIPTION
Using hashCode() can provide false positives due to collisions. Instead, we should directly check that the codes are equal.