### PR TITLE
Bump Java version to 1.0.1.

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -76,3 +76,9 @@ INFO: Elapsed time: 0.657s, Critical Path: 0.46s
 Executed 4 out of 4 tests: 4 tests pass.
 $
 ```
+
+## MavenCentral
+
+The library is available to import/download via [Maven Central](https://search.maven.org/search?q=g:com.google.openlocationcode).
+
+To update the library, bump the version number in pom.xml and run "mvn clean deploy" from the java folder. See the [docs](https://central.sonatype.org/pages/apache-maven.html) for more info.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
  
   <groupId>com.google.openlocationcode</groupId>
   <artifactId>openlocationcode</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
 
   <name>Open Location Code</name>


### PR DESCRIPTION
New version available at https://search.maven.org/artifact/com.google.openlocationcode/openlocationcode/1.0.1/jar.