### PR TITLE
Remove unused constant kMinShortenDegrees

### DIFF
--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -22,7 +22,6 @@ const size_t kEncodingBase = 20;
 const size_t kPairCodeLength = 10;
 const size_t kGridColumns = 4;
 const size_t kGridRows = kEncodingBase / kGridColumns;
-const double kMinShortenDegrees = 0.05;
 // Work out the encoding base exponent necessary to represent 360 degrees.
 const size_t kInitialExponent = floor(log(360) / log(kEncodingBase));
 // Work out the enclosing resolution (in degrees) for the grid algorithm.

--- a/cpp/openlocationcode.h
+++ b/cpp/openlocationcode.h
@@ -101,9 +101,6 @@ extern const size_t kPairCodeLength;
 extern const size_t kGridColumns;
 // Number of rows in the grid refinement method.
 extern const size_t kGridRows;
-// Defines the minimum pair resolution (in degrees) to remove when shortening a
-// code.
-extern const double kMinShortenDegrees;
 // Gives the exponent used for the first pair.
 extern const size_t kInitialExponent;
 // Size of the initial grid in degrees. This is the size of the area represented

--- a/cpp/openlocationcode_test.cc
+++ b/cpp/openlocationcode_test.cc
@@ -47,10 +47,6 @@ TEST(ParameterChecks, SeparatorPositionValid) {
   EXPECT_TRUE(internal::kSeparatorPosition <= internal::kPairCodeLength);
 }
 
-TEST(ParameterChecks, ShortenDegreesValid) {
-  EXPECT_TRUE(internal::kMinShortenDegrees >= internal::kGridSizeDegrees);
-}
-
 }  // namespace
 }  // namespace internal
 


### PR DESCRIPTION
I realized this constant was unused when I was cloning the C++ tests into the C implementation.

I am not 100% sure if it is OK to remove this (the repo doesn't reference it at all), so please feel free to reject this PR if this is wrong.