### PR TITLE
Fix decoding bug in C implementation

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -9,6 +9,8 @@ C_FLAGS += -Wall
 # C_FLAGS += -Wextra
 C_FLAGS += -Wno-comment
 
+LD_FLAGS += -lm
+
 ALL_FLAGS += -std=c99
 ALL_FLAGS += -g
 
@@ -26,10 +28,10 @@ $(LIB_A_FILE): $(LIB_OBJ_FILES)
 	ar rvs $@ $^
 
 example: example.o $(LIB_A_FILE)
-	$(CC) $(ALL_FLAGS) -o $@ example.o -L. -l$(LIB_NAME)
+	$(CC) $(ALL_FLAGS) -o $@ example.o $(LD_FLAGS) -L. -l$(LIB_NAME)
 
 olc_test: olc_test.o $(LIB_A_FILE)
-	$(CC) $(ALL_FLAGS) -o $@ olc_test.o -L. -l$(LIB_NAME)
+	$(CC) $(ALL_FLAGS) -o $@ olc_test.o $(LD_FLAGS) -L. -l$(LIB_NAME)
 
 lib: $(LIB_A_FILE)
 
@@ -39,7 +41,7 @@ test: olc_test
 clean:
 	rm -f crash-* slow-unit-* *.dSYM
 	rm -f $(LIB_OBJ_FILES) $(LIB_A_FILE)
-	rm -f example. olc_test.o
+	rm -f example.o olc_test.o
 	rm -f example olc_test
 	rm -f olc_test
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -39,7 +39,8 @@ test: olc_test
 clean:
 	rm -f crash-* slow-unit-* *.dSYM
 	rm -f $(LIB_OBJ_FILES) $(LIB_A_FILE)
-	rm -f example
+	rm -f example. olc_test.o
+	rm -f example olc_test
 	rm -f olc_test
 
 install: libolc.a olc.h

--- a/c/example.c
+++ b/c/example.c
@@ -17,12 +17,12 @@ int main(int argc, char* argv[])
     // Encodes latitude and longitude into a Plus+Code with a preferred length.
     len = OLC_Encode(&location, 16, code, 256);
     printf("%s (%d)\n", code, len);
-    // => "8FVC2222+22GCCCCC"
+    // => "8FVC2222+22GCCCC"
 
     // Decodes a Plus+Code back into coordinates.
     OLC_CodeArea code_area;
     OLC_Decode(code, 0, &code_area);
-    printf("Code length: %14.10f : %14.10f to %14.10f : %14.10f (%lu)\n",
+    printf("Code length: %.15f : %.15f to %.15f : %.15f (%lu)\n",
            code_area.lo.lat,
            code_area.lo.lon,
            code_area.hi.lat,

--- a/c/olc.c
+++ b/c/olc.c
@@ -270,7 +270,7 @@ static int analyse(const char* code, size_t size, CodeInfo* info)
     info->pad_first = -1;
     info->pad_last = -1;
     int j = 0;
-    for (j = 0; j < size && code[j] != '\0'; ++j) {
+    for (j = 0; j <= size && code[j] != '\0'; ++j) {
         int ok = 0;
 
         // if this is a padding character, remember it
@@ -476,6 +476,7 @@ static int decode(CodeInfo* info, OLC_CodeArea* decoded)
         top = info->len;
         if (top > kMaximumDigitCount) {
             top = kMaximumDigitCount;
+            CORRECT_IF_SEPARATOR(top, info);
         }
         int bot = kPairCodeLength;
         CORRECT_IF_SEPARATOR(bot, info);

--- a/c/olc.h
+++ b/c/olc.h
@@ -28,10 +28,12 @@ int OLC_IsShort(const char* code, size_t size);
 int OLC_IsFull(const char* code, size_t size);
 
 // Encode location with given code length (indicates precision) into an OLC
+// Return the string length of the code
 int OLC_Encode(const OLC_LatLon* location, size_t code_length,
                char* code, int maxlen);
 
 // Encode location with default code length into an OLC
+// Return the string length of the code
 int OLC_EncodeDefault(const OLC_LatLon* location,
                       char* code, int maxlen);
 

--- a/c/olc_private.h
+++ b/c/olc_private.h
@@ -3,27 +3,32 @@
  * include the file in both the library and the tests.
  */
 
+#define OLC_kEncodingBase      20
+#define OLC_kGridCols          4
+#define OLC_kLatMaxDegrees     90
+#define OLC_kLonMaxDegrees     180
+
 static const char   kSeparator         = '+';
 static const size_t kSeparatorPosition = 8;
 static const char   kPaddingCharacter  = '0';
 static const char   kAlphabet[]        = "23456789CFGHJMPQRVWX";
-static const size_t kEncodingBase      = 20;
+static const size_t kEncodingBase      = OLC_kEncodingBase;
 static const size_t kPairCodeLength    = 10;
-static const size_t kGridCols          = 4;
-static const size_t kGridRows          = kEncodingBase / kGridCols;
+static const size_t kGridCols          = OLC_kGridCols;
+static const size_t kGridRows          = OLC_kEncodingBase / OLC_kGridCols;
 
 // The max number of digits returned in a plus code. Roughly 1 x 0.5 cm.
 static const size_t kMaximumDigitCount = 15;
 
 // Latitude bounds are -kLatMaxDegrees degrees and +kLatMaxDegrees degrees
 // which we transpose to 0 and 180 degrees.
-static const double kLatMaxDegrees     = 90;
-static const double kLatMaxDegreesT2   = 2 * kLatMaxDegrees;
+static const double kLatMaxDegrees     = OLC_kLatMaxDegrees;
+static const double kLatMaxDegreesT2   = 2 * OLC_kLatMaxDegrees;
 
 // Longitude bounds are -kLonMaxDegrees degrees and +kLonMaxDegrees degrees
 // which we transpose to 0 and 360 degrees.
-static const double kLonMaxDegrees     = 180;
-static const double kLonMaxDegreesT2   = 2 * kLonMaxDegrees;
+static const double kLonMaxDegrees     = OLC_kLonMaxDegrees;
+static const double kLonMaxDegreesT2   = 2 * OLC_kLonMaxDegrees;
 
 // These will be defined later, during runtime.
 static size_t kInitialExponent          = 0;

--- a/c/olc_test.c
+++ b/c/olc_test.c
@@ -73,7 +73,7 @@ TEST(Extra, LongCodes)
     EXPECT_STR_EQ(code, "8FVC2222+22");
 
     // Encodes latitude and longitude into a Plus+Code with a preferred length.
-    len = OLC_Encode(&location, 16, code, 256);
+    len = OLC_Encode(&location, 15, code, 256);
     EXPECT_NUM_EQ(len, 16);
     EXPECT_STR_EQ(code, "8FVC2222+22GCCCC");
 

--- a/c/olc_test.c
+++ b/c/olc_test.c
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include "olc.h"
 #include "olc_private.h"
 #include "tests.h"
@@ -88,6 +89,13 @@ TEST(Extra, LongCodes)
     EXPECT_NUM_EQ(code_area.lo.lon,  8.000062500000013);
     EXPECT_NUM_EQ(code_area.hi.lat, 47.000062520000000);
     EXPECT_NUM_EQ(code_area.hi.lon,  8.000062622070317);
+}
+
+TEST(ParameterChecks, SilenceWarningsForConstants)
+{
+  EXPECT_NUM_EQ(kInitialExponent, 0);
+  EXPECT_NUM_EQ(kGridSizeDegrees, 0.0);
+  EXPECT_NUM_EQ(kInitialResolutionDegrees, 0.0);
 }
 
 static int process_file(const char* file, TestFunc func)
@@ -305,6 +313,7 @@ int main(int argc, char* argv[])
     test_ParameterChecks_AlphabetIsOrdered();
     test_ParameterChecks_PositionLUTMatchesAlphabet();
     test_ParameterChecks_SeparatorPositionValid();
+    test_ParameterChecks_SilenceWarningsForConstants();
     test_Extra_LongCodes();
 
     test_csv_files();

--- a/c/olc_test.c
+++ b/c/olc_test.c
@@ -77,6 +77,9 @@ TEST(Extra, LongCodes)
     EXPECT_NUM_EQ(len, 16);
     EXPECT_STR_EQ(code, "8FVC2222+22GCCCC");
 
+    len = OLC_CodeLength(code, 256);
+    EXPECT_NUM_EQ(len, 15);
+
     // Decodes a Plus+Code back into coordinates.
     OLC_CodeArea code_area;
     len = OLC_Decode(code, 0, &code_area);

--- a/c/tests.h
+++ b/c/tests.h
@@ -5,18 +5,32 @@
 
 #define TEST(group, name) static void test_ ## group ## _ ## name (void)
 
-#define EXPECT_BINOP(op, a, b) \
+#define EXPECT_NUM_BINOP(op, a, b) \
     do { \
-        int ok = (a) op (b); \
-        fprintf(stderr, "%-3.3s [%s] %s [%s]\n", ok ? "OK" : "BAD", #a, #op, #b); \
-        /* if (!ok) { abort(); } */ \
+        int test_expect_ok = (a) op (b); \
+        fprintf(stderr, "%-3.3s [%s] %s [%s]\n", test_expect_ok ? "OK" : "BAD", #a, #op, #b); \
+        /* if (!test_expect_ok) { abort(); } */ \
     } while (0)
 
-#define EXPECT_EQ(a, b) EXPECT_BINOP(==, a, b)
-#define EXPECT_NE(a, b) EXPECT_BINOP(!=, a, b)
-#define EXPECT_LT(a, b) EXPECT_BINOP(< , a, b)
-#define EXPECT_LE(a, b) EXPECT_BINOP(<=, a, b)
-#define EXPECT_GT(a, b) EXPECT_BINOP(> , a, b)
-#define EXPECT_GE(a, b) EXPECT_BINOP(>=, a, b)
+#define EXPECT_STR_BINOP(op, a, b) \
+    do { \
+        int test_expect_ok = strcmp((a), (b)) op 0; \
+        fprintf(stderr, "%-3.3s [%s] %s [%s]\n", test_expect_ok ? "OK" : "BAD", #a, #op, #b); \
+        /* if (!test_expect_ok) { abort(); } */ \
+    } while (0)
+
+#define EXPECT_NUM_EQ(a, b) EXPECT_NUM_BINOP(==, a, b)
+#define EXPECT_NUM_NE(a, b) EXPECT_NUM_BINOP(!=, a, b)
+#define EXPECT_NUM_LT(a, b) EXPECT_NUM_BINOP(< , a, b)
+#define EXPECT_NUM_LE(a, b) EXPECT_NUM_BINOP(<=, a, b)
+#define EXPECT_NUM_GT(a, b) EXPECT_NUM_BINOP(> , a, b)
+#define EXPECT_NUM_GE(a, b) EXPECT_NUM_BINOP(>=, a, b)
+
+#define EXPECT_STR_EQ(a, b) EXPECT_STR_BINOP(==, a, b)
+#define EXPECT_STR_NE(a, b) EXPECT_STR_BINOP(!=, a, b)
+#define EXPECT_STR_LT(a, b) EXPECT_STR_BINOP(< , a, b)
+#define EXPECT_STR_LE(a, b) EXPECT_STR_BINOP(<=, a, b)
+#define EXPECT_STR_GT(a, b) EXPECT_STR_BINOP(> , a, b)
+#define EXPECT_STR_GE(a, b) EXPECT_STR_BINOP(>=, a, b)
 
 #endif


### PR DESCRIPTION
Bug was due to two things (so, maybe two bugs):

1. Not considering the full size of a 16 characters code.
2. Not correcting the top position when the code includes a separator,
   which made it process fewer grid square characters.

A new test was added to make sure this is (and remains) fixed.