### PR TITLE
Add C implementation to TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ dist: trusty
 
 matrix:
   include:
+    # C implementation. Lives in c/, tested with make.
+    - language: c
+      env: OLC_PATH=c
+      script:
+        - cd ${OLC_PATH};make test
+
     # C++ implementation. Lives in cpp/, tested with bazel.
     - language: cpp
       env: OLC_PATH=cpp

--- a/c/Makefile
+++ b/c/Makefile
@@ -28,10 +28,10 @@ $(LIB_A_FILE): $(LIB_OBJ_FILES)
 	ar rvs $@ $^
 
 example: example.o $(LIB_A_FILE)
-	$(CC) $(ALL_FLAGS) -o $@ example.o $(LD_FLAGS) -L. -l$(LIB_NAME)
+	$(CC) $(ALL_FLAGS) -o $@ example.o -L. -l$(LIB_NAME) $(LD_FLAGS)
 
 olc_test: olc_test.o $(LIB_A_FILE)
-	$(CC) $(ALL_FLAGS) -o $@ olc_test.o $(LD_FLAGS) -L. -l$(LIB_NAME)
+	$(CC) $(ALL_FLAGS) -o $@ olc_test.o -L. -l$(LIB_NAME) $(LD_FLAGS)
 
 lib: $(LIB_A_FILE)
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -22,7 +22,7 @@ LIB_OBJ_FILES = $(LIB_C_FILES:.c=.o)
 LIB_A_FILE = lib$(LIB_NAME).a
 
 %.o : %.c
-	$(CC) -c $(ALL_FLAGS) $(C_FLAGS) $(CPP_FLAGS) -o $@ $<
+	$(CC) -c $(ALL_FLAGS) $(C_FLAGS) $(CPP_FLAGS) $(LD_FLAGS) -o $@ $<
 
 $(LIB_A_FILE): $(LIB_OBJ_FILES)
 	ar rvs $@ $^

--- a/c/Makefile
+++ b/c/Makefile
@@ -22,7 +22,7 @@ LIB_OBJ_FILES = $(LIB_C_FILES:.c=.o)
 LIB_A_FILE = lib$(LIB_NAME).a
 
 %.o : %.c
-	$(CC) -c $(ALL_FLAGS) $(C_FLAGS) $(CPP_FLAGS) $(LD_FLAGS) -o $@ $<
+	$(CC) -c $(ALL_FLAGS) $(C_FLAGS) $(CPP_FLAGS) -o $@ $< $(LD_FLAGS)
 
 $(LIB_A_FILE): $(LIB_OBJ_FILES)
 	ar rvs $@ $^


### PR DESCRIPTION
Compilers are sensitive to the presence and order of -lm.