### PR TITLE
Add library version information

### DIFF
--- a/c/example.c
+++ b/c/example.c
@@ -7,6 +7,11 @@ int main(int argc, char* argv[])
     int len;
     OLC_LatLon location;
 
+    // Show current version
+    printf("=== OLC version [%s] -- %d -- [%d] [%d] [%d] ===\n",
+           OLC_VERSION_STR, OLC_VERSION_NUM,
+           OLC_VERSION_MAJOR, OLC_VERSION_MINOR, OLC_VERSION_PATCH);
+
     // Encodes latitude and longitude into a Plus+Code.
     location.lat = 47.0000625;
     location.lon =  8.0000625;

--- a/c/olc.h
+++ b/c/olc.h
@@ -3,6 +3,29 @@
 
 #include <stdlib.h>
 
+#define OLC_VERSION_MAJOR 1
+#define OLC_VERSION_MINOR 0
+#define OLC_VERSION_PATCH 2
+
+// OLC version number: 2.3.4 => 2003004
+// Useful for checking against a particular version or above:
+//
+// #if OLC_VERSION_NUM < OLC_MAKE_VERSION_NUM(1, 0, 2)
+// #error UNSUPPORTED OLC VERSION
+// #endif
+#define OLC_MAKE_VERSION_NUM(major, minor, patch) \
+    ((major * 1000 + minor) * 1000 + patch)
+
+// OLC version string: 2.3.4 => "2.3.4"
+#define OLC_MAKE_VERSION_STR_IMPL(major, minor, patch) \
+    (#major "." #minor  "." #patch)
+#define OLC_MAKE_VERSION_STR(major, minor, patch) \
+    OLC_MAKE_VERSION_STR_IMPL(major, minor, patch)
+
+// Current version, as a number and a string
+#define OLC_VERSION_NUM OLC_MAKE_VERSION_NUM(OLC_VERSION_MAJOR, OLC_VERSION_MINOR, OLC_VERSION_PATCH)
+#define OLC_VERSION_STR OLC_MAKE_VERSION_STR(OLC_VERSION_MAJOR, OLC_VERSION_MINOR, OLC_VERSION_PATCH)
+
 // A pair of doubles representing latitude / longitude
 typedef struct OLC_LatLon {
     double lat;

--- a/c/olc.h
+++ b/c/olc.h
@@ -5,7 +5,7 @@
 
 #define OLC_VERSION_MAJOR 1
 #define OLC_VERSION_MINOR 0
-#define OLC_VERSION_PATCH 2
+#define OLC_VERSION_PATCH 0
 
 // OLC version number: 2.3.4 => 2003004
 // Useful for checking against a particular version or above:

--- a/c/olc_test.c
+++ b/c/olc_test.c
@@ -98,6 +98,13 @@ TEST(Extra, Version)
     EXPECT_NUM_GE(current_version, minimum_version);
 }
 
+TEST(ParameterChecks, SilenceWarningsForConstants)
+{
+  EXPECT_NUM_EQ(kInitialExponent, 0);
+  EXPECT_NUM_EQ(kGridSizeDegrees, 0.0);
+  EXPECT_NUM_EQ(kInitialResolutionDegrees, 0.0);
+}
+
 static int process_file(const char* file, TestFunc func)
 {
     static char* base_dir[] = {

--- a/c/olc_test.c
+++ b/c/olc_test.c
@@ -94,7 +94,7 @@ TEST(Extra, LongCodes)
 TEST(Extra, Version)
 {
     int current_version = OLC_VERSION_NUM;
-    int minimum_version = OLC_MAKE_VERSION_NUM(1, 0, 2);
+    int minimum_version = OLC_MAKE_VERSION_NUM(1, 0, 0);
     EXPECT_NUM_GE(current_version, minimum_version);
 }
 

--- a/c/olc_test.c
+++ b/c/olc_test.c
@@ -91,11 +91,11 @@ TEST(Extra, LongCodes)
     EXPECT_NUM_EQ(code_area.hi.lon,  8.000062622070317);
 }
 
-TEST(ParameterChecks, SilenceWarningsForConstants)
+TEST(Extra, Version)
 {
-  EXPECT_NUM_EQ(kInitialExponent, 0);
-  EXPECT_NUM_EQ(kGridSizeDegrees, 0.0);
-  EXPECT_NUM_EQ(kInitialResolutionDegrees, 0.0);
+    int current_version = OLC_VERSION_NUM;
+    int minimum_version = OLC_MAKE_VERSION_NUM(1, 0, 2);
+    EXPECT_NUM_GE(current_version, minimum_version);
 }
 
 static int process_file(const char* file, TestFunc func)
@@ -309,6 +309,7 @@ static void test_csv_files(void)
 
 int main(int argc, char* argv[])
 {
+    test_Extra_Version();
     test_ParameterChecks_PairCodeLengthIsEven();
     test_ParameterChecks_AlphabetIsOrdered();
     test_ParameterChecks_PositionLUTMatchesAlphabet();


### PR DESCRIPTION
We define the customary macros to be able to get the library version as
a comparable number, a printable string and as separate numeric values
for major, minor and patch.  Test included.  Arbitrarily start at 1.0.2.