### PR TITLE
Add "Positioning" permission to the app

### DIFF
--- a/garmin/PlusCodeDatafield/manifest.xml
+++ b/garmin/PlusCodeDatafield/manifest.xml
@@ -25,6 +25,7 @@
         </iq:products>
 
         <iq:permissions>
+            <iq:uses-permission id="Positioning"/>
         </iq:permissions>
 
         <iq:languages>


### PR DESCRIPTION
https://developer.garmin.com/index.php/blog/post/changes-to-the-position-permission: "In the past developers have had access to the user’s position via the Toybox.Activity.Info.currentLocation without a permission. This API provides live position information to data fields operating within an activity, and can be used by Watch Faces to acquire a last known location. In an upcoming change to Connect IQ, we will be changing the behavior of this API and require the Position permission. This change will be made retroactively back to Connect IQ 1.x devices, so developers should add the Position permission to their apps (including for Connect IQ 1.x products) before June 30th. Failure to do so will cause your apps to stop working after this change is implemented."