### PR TITLE
Update Garmin build files and docs

### DIFF
--- a/garmin/PlusCodeDatafield/README.md
+++ b/garmin/PlusCodeDatafield/README.md
@@ -88,5 +88,13 @@ You'll need a developer key, see [Generating a Developer Key](https://developer.
 Then from this directory in your GitHub repo, you should be able to run:
 
 ```shell
-~/connectiq/bin/monkeyc -w -y ~/Downloads/developer_key -f monkey.jungle -o bin/PlusCodeDatafield.prg
+~/connectiq/bin/monkeyc -w -y ~/developer_key -f monkey.jungle -o bin/PlusCodeDatafield.prg
 ``` 
+
+That gives you a `.prg` file that can be run in the simulator.
+
+To build the `.iq` file with a binary for each device (this is the Export Wizard's function), you need to run (this assumes the SDK is in `~/connectiq` and your develper key is in `~/developer_key`):
+
+```shell
+~/connectiq/bin/monkeyc -w -y ~/developer_key -f monkey.jungle -e -a ~/connectiq/bin/api.db -i ~/connectiq/bin/api.debug.xml -o PlusCodeDataField.iq -w -u ~/connectiq/bin/devices.xml -p ~/connectiq/bin/projectInfo.xml
+```

--- a/garmin/PlusCodeDatafield/README.md
+++ b/garmin/PlusCodeDatafield/README.md
@@ -79,11 +79,14 @@ Create an issue on the project site by
 
 ## Using Connect IQ on Linux
 
-See [this overview](http://blog.aaronboman.com/programming/connectiq/2014/11/13/the-garmin-connect-iq-sdk-on-ubuntu-linux/)
-for general information.
+The Garmin Connect IQ SDK is now available for Linux. Depending on your exact version the simulator may or may not run (it has specific dependencies) but the compiler appears to be reliable.
 
-There seem to have been some changes to the `monkeyc` command since that blog
-article was published:
+Install the SDK from the [SDK page](http://developer.garmin.com/connect-iq/sdk/), and unzip it somewhere handy (like `~/connectiq`).
 
-* You must include your [developer key](https://developer.garmin.com/connect-iq/programmers-guide/getting-started/#generatingadeveloperkeyciq1.3) with the `-y` option
-* You must include the source files on the command line 
+You'll need a developer key, see [Generating a Developer Key](https://developer.garmin.com/connect-iq/programmers-guide/getting-started/#generatingadeveloperkeyciq1.3).
+
+Then from this directory in your GitHub repo, you should be able to run:
+
+```shell
+~/connectiq/bin/monkeyc -w -y ~/Downloads/developer_key -f monkey.jungle -o bin/PlusCodeDatafield.prg
+``` 

--- a/garmin/PlusCodeDatafield/monkey.jungle
+++ b/garmin/PlusCodeDatafield/monkey.jungle
@@ -1,0 +1,1 @@
+project.manifest = manifest.xml


### PR DESCRIPTION
Current Connect IQ SDK (v3) has removed some command line flags and replaced them with [`jungle`](http://developer.garmin.com/connect-iq/programmers-guide/overriding-resources/) files. (I think they're carrying on with the monkey thing a bit much tbh.)