### PR TITLE
Update version for Swift

### DIFF
--- a/swift/README.md
+++ b/swift/README.md
@@ -1,1 +1,1 @@
-Curbmap have a Swift 3.x implementation cocoapod located [here](https://github.com/curbmap/OpenLocationCode-swift).
+Curbmap have a Swift 4.x implementation cocoapod located [here](https://github.com/curbmap/OpenLocationCode-swift).


### PR DESCRIPTION
This library now supports Swift 4.2

https://github.com/curbmap/OpenLocationCode-swift/blob/master/CHANGELOG