### PR TITLE
Renumber grid-cell for lexical nearness

### DIFF
--- a/docs/olc_definition.adoc
+++ b/docs/olc_definition.adoc
@@ -385,11 +385,11 @@ shown. Repeat as many times as necessary.
 +
 [options="autowidth"]
 |=======================
-|R|V|W|X
-|J|M|P|Q
-|C|F|G|H
-|6|7|8|9
-|2|3|4|5
+|M|R|W|X
+|F|H|P|V
+|7|8|G|Q
+|4|5|9|J
+|2|3|6|C
 |=======================
 +
 


### PR DESCRIPTION
To enhance the lexical sortability of the sub-grid, assign the grid numbers in a radius pattern from the lower left cell. This adds the feature that the distance from the left-corner of the cell is somewhat apparent from the grid values.

This means that two extended codes that are compared will be ordered more reasonably.

This **is** a breaking change, so a *vast and overwhelming consensus* would be required. 