### PR TITLE
Fix Java isValidCode() to validate separator position as defined by the spec

### DIFF
--- a/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
@@ -507,22 +507,20 @@ public final class OpenLocationCode {
     if (separatorPosition != code.lastIndexOf(SEPARATOR)) {
       return false;
     }
-
-    if (separatorPosition % 2 != 0) {
+    // There must be an even number of at most 8 characters before the separator.
+    if (separatorPosition % 2 != 0 || separatorPosition > SEPARATOR_POSITION) {
       return false;
     }
 
     // Check first two characters: only some values from the alphabet are permitted.
-    if (separatorPosition == 8) {
+    if (separatorPosition == SEPARATOR_POSITION) {
       // First latitude character can only have first 9 values.
-      Integer index0 = CODE_ALPHABET.indexOf(code.charAt(0));
-      if (index0 == null || index0 > 8) {
+      if (CODE_ALPHABET.indexOf(code.charAt(0)) > 8) {
         return false;
       }
 
       // First longitude character can only have first 18 values.
-      Integer index1 = CODE_ALPHABET.indexOf(code.charAt(1));
-      if (index1 == null || index1 > 17) {
+      if (CODE_ALPHABET.indexOf(code.charAt(1)) > 17) {
         return false;
       }
     }

--- a/test_data/validityTests.csv
+++ b/test_data/validityTests.csv
@@ -18,6 +18,7 @@ G+,false,false,false
 8FWC2_45+G6,false,false,false
 8FWC2η45+G6,false,false,false
 8FWC2345+G6+,false,false,false
+8FWC2345G6+,false,false,false
 8FWC2300+G6,false,false,false
 WC2300+G6g,false,false,false
 WC2345+G,false,false,false


### PR DESCRIPTION
The API reference for the isValid() method specifies:
> There must be an even number of at most eight characters before the separator.

The current Java implementation fails to validate that there are at most eight characters before the separator.  For example, these invalid codes would pass the isValid check and ultimately break the operations.
```
8FWC2345G6+
8FWC2345G600+
8FWC2345G62222222222+
```
This PR fixes this by checking that the separator position is also not greater than 8 just like the other implementations do.
One of the above examples was also added to `validityTests.csv` to validate this test case.