### PR TITLE
Update Python library visibility to public.

### DIFF
--- a/python/BUILD
+++ b/python/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 py_library(
     name = "openlocationcode",
     srcs = ["openlocationcode.py"],


### PR DESCRIPTION
Anyone pulling in the library using Blaze/Bazel currently won't be able to reference the library. This updates the default visibility to public.