### PR TITLE
Require Go files to be correctly formatted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,12 @@ matrix:
       script:
         - cd dart && pub get && pub run test
 
-    # Go implementation. Lives in go/
+    # Go implementation. Lives in go/. Tests fail if files have not been formatted with gofmt.
     - language: go
       go: stable
       env: OLC_PATH=go
       script:
+        - diff -u <(echo -n) <(gofmt -d -s ./go)
         - go test -bench=. ./go -v
         - go test ./tile_server/gridserver -v
 

--- a/go/README.md
+++ b/go/README.md
@@ -1,5 +1,15 @@
 [![GoDoc](https://godoc.org/github.com/google/open-location-code/go?status.svg)](http://godoc.org/github.com/google/open-location-code/go)
 
+# Formatting
+
+Go files must be formatted with [gofmt](https://golang.org/cmd/gofmt/), and the
+tests will check that this is the case. If the files are not correctly
+formatted, the tests will fail.
+
+You can format your files by running:
+
+	gofmt -w -s .
+
 # Install
 
 	go get github.com/google/open-location-code/go

--- a/go/olc_test.go
+++ b/go/olc_test.go
@@ -300,11 +300,11 @@ func BenchmarkEncode(b *testing.B) {
 	lat := make([]float64, b.N)
 	lng := make([]float64, b.N)
 	for i := 0; i < b.N; i++ {
-		lat[i] = r.Float64()*180-90
-		lng[i] = r.Float64()*360-180
+		lat[i] = r.Float64()*180 - 90
+		lng[i] = r.Float64()*360 - 180
 	}
 	// Reset the timer and run the benchmark.
-  b.ResetTimer()
+	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		olc.Encode(lat[i], lng[i], 16)
@@ -319,7 +319,7 @@ func BenchmarkDecode(b *testing.B) {
 		codes[i] = olc.Encode(r.Float64()*180-90, r.Float64()*360-180, 16)
 	}
 	// Reset the timer and run the benchmark.
-  b.ResetTimer()
+	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		olc.Decode(codes[i])

--- a/go/shorten.go
+++ b/go/shorten.go
@@ -95,20 +95,20 @@ func RecoverNearest(code string, lat, lng float64) (string, error) {
 	// than half the resolution, we need to move it south or north but keep it
 	// within -90 to 90 degrees.
 	centerLat, centerLng := area.Center()
-	if lat + halfRes < centerLat && centerLat - resolution >= -latMax {
+	if lat+halfRes < centerLat && centerLat-resolution >= -latMax {
 		// If the proposed code is more than half a cell north of the reference location,
 		// it's too far, and the best match will be one cell south.
 		centerLat -= resolution
-	} else if lat - halfRes > centerLat && centerLat + resolution <= latMax {
+	} else if lat-halfRes > centerLat && centerLat+resolution <= latMax {
 		// If the proposed code is more than half a cell south of the reference location,
 		// it's too far, and the best match will be one cell north.
 		centerLat += resolution
 	}
 
 	// How many degrees longitude is the code from the reference?
-	if lng + halfRes < centerLng {
+	if lng+halfRes < centerLng {
 		centerLng -= resolution
-	} else if lng - halfRes > centerLng {
+	} else if lng-halfRes > centerLng {
 		centerLng += resolution
 	}
 


### PR DESCRIPTION
Add in a check in the continuous integration to fail if Go files are not formatted correctly.
Format the current Go files.