### PR TITLE
Add test data to verify behavior of recovering full codes

### DIFF
--- a/test_data/shortCodeTests.csv
+++ b/test_data/shortCodeTests.csv
@@ -29,3 +29,5 @@
 # This tests recovery function, but these codes won't shorten.
 CFX22222+22,89.6,0.0,2222+22,R
 2CXXXXXX+XX,-81.0,0.0,XXXXXX+XX,R
+# Recovered full codes should be the full code
+8FRCG2GG+GG,46.526,7.976,8FRCG2GG+GG,R


### PR DESCRIPTION
Per https://github.com/google/open-location-code/issues/128, when passed a full code, the recover function should return the full code.

This PR adds test data to verify that behavior.