### PR TITLE
Return uppercased code in recoverNearest in all implementations

### DIFF
--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -303,7 +303,9 @@ std::string Shorten(const std::string &code, const LatLng &reference_location) {
 std::string RecoverNearest(const std::string &short_code,
                            const LatLng &reference_location) {
   if (!IsShort(short_code)) {
-    return short_code;
+    std::string code = short_code;
+    std::transform(code.begin(), code.end(), code.begin(), ::toupper);
+    return code;
   }
   // Ensure that latitude and longitude are valid.
   double latitude =

--- a/dart/lib/src/open_location_code.dart
+++ b/dart/lib/src/open_location_code.dart
@@ -311,7 +311,7 @@ String recoverNearest(
     String shortCode, num referenceLatitude, num referenceLongitude) {
   if (!isShort(shortCode)) {
     if (isFull(shortCode)) {
-      return shortCode;
+      return shortCode.toUpperCase();
     } else {
       throw ArgumentError('Passed short code is not valid: $shortCode');
     }

--- a/go/shorten.go
+++ b/go/shorten.go
@@ -64,10 +64,12 @@ func Shorten(code string, lat, lng float64) (string, error) {
 // Given a short Open Location Code with from four to eight digits missing,
 // this recovers the nearest matching full code to the specified location.
 func RecoverNearest(code string, lat, lng float64) (string, error) {
+	// Return uppercased code if a full code was passed.
+	if err := CheckFull(code); err == nil {
+		return strings.ToUpper(code), nil
+	}
+	// Return error if not a short code
 	if err := CheckShort(code); err != nil {
-		if err = CheckFull(code); err == nil {
-			return code, nil
-		}
 		return code, ErrNotShort
 	}
 	// Ensure that latitude and longitude are valid.

--- a/js/closure/openlocationcode.js
+++ b/js/closure/openlocationcode.js
@@ -432,7 +432,7 @@ function recoverNearest(
     shortCode, referenceLatitude, referenceLongitude) {
   if (!isShort(shortCode)) {
     if (isFull(shortCode)) {
-      return shortCode;
+      return shortCode.toUpperCase();
     } else {
       throw 'ValueError: Passed short code is not valid: ' + shortCode;
     }

--- a/js/src/openlocationcode.js
+++ b/js/src/openlocationcode.js
@@ -366,7 +366,7 @@
       shortCode, referenceLatitude, referenceLongitude) {
     if (!isShort(shortCode)) {
       if (isFull(shortCode)) {
-        return shortCode;
+        return shortCode.toUpperCase();
       } else {
         throw 'ValueError: Passed short code is not valid: ' + shortCode;
       }

--- a/ruby/lib/plus_codes/open_location_code.rb
+++ b/ruby/lib/plus_codes/open_location_code.rb
@@ -113,7 +113,7 @@ module PlusCodes
     # @param reference_longitude [Numeric] a reference longitude in degrees
     # @return [String] a plus+codes
     def recover_nearest(short_code, reference_latitude, reference_longitude)
-      return short_code if full?(short_code)
+      return short_code.upcase if full?(short_code)
       raise ArgumentError,
       "Open Location Code(Plus+Codes) is not valid: #{short_code}" unless short?(short_code)
 

--- a/rust/src/interface.rs
+++ b/rust/src/interface.rs
@@ -262,7 +262,7 @@ pub fn shorten(_code: &str, ref_pt: Point<f64>) -> Result<String, String> {
 pub fn recover_nearest(_code: &str, ref_pt: Point<f64>) -> Result<String, String> {
     if !is_short(_code) {
         if is_full(_code) {
-            return Ok(_code.to_string());
+            return Ok(_code.to_string().to_uppercase());
         } else {
             return Err(format!("Passed short code is not valid: {}", _code));
         }

--- a/test_data/shortCodeTests.csv
+++ b/test_data/shortCodeTests.csv
@@ -31,3 +31,5 @@ CFX22222+22,89.6,0.0,2222+22,R
 2CXXXXXX+XX,-81.0,0.0,XXXXXX+XX,R
 # Recovered full codes should be the full code
 8FRCG2GG+GG,46.526,7.976,8FRCG2GG+GG,R
+# Recovered full codes should be the uppercased full code
+8FRCG2GG+GG,46.526,7.976,8frCG2GG+gG,R


### PR DESCRIPTION
Unify the behavior when a full code is given to `recoverNearest` with lowercase characters by always returning the uppercased code. Currently, some implementations return the uppercased full code while others will return it unmodified.

Rolls out changes made in #128 to the Python implementation (`recoverNearest` returns uppercased full code) to remaining implementations.