### PR TITLE
Update gulp version, remove dependency on gulp-util

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "gulp-qunit": "^1.0.0",
-    "gulp-util": "^3.0.0",
     "gulp": "^3.8.9"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -21,7 +21,7 @@
     "test": "cd test && gulp test"
   },
   "devDependencies": {
-    "gulp-qunit": "^1.0.0",
+    "gulp-qunit": "^2.0.0",
     "gulp": "^4.0.0"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "gulp-qunit": "^1.0.0",
-    "gulp": "^3.8.9"
+    "gulp": "^4.0.0"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -18,7 +18,7 @@
     "openlocationcode"
   ],
   "scripts": {
-    "test": "cd test && gulp"
+    "test": "cd test && gulp test"
   },
   "devDependencies": {
     "gulp-qunit": "^1.0.0",

--- a/js/test/gulpfile.js
+++ b/js/test/gulpfile.js
@@ -4,5 +4,3 @@ var qunit = require('gulp-qunit');
 gulp.task('test', function() {
   return gulp.src('./test.html').pipe(qunit());
 });
-
-gulp.task('default', ['test']);


### PR DESCRIPTION
Fix failing JS tests.

NodeJS tests were failing with:

```
9.31s$ cd js && npm install && npm test
npm WARN deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
npm WARN deprecated graceful-fs@3.0.11: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated natives@1.1.6: This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@1.2.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
> phantomjs-prebuilt@2.1.16 install /home/travis/build/google/open-location-code/js/node_modules/phantomjs-prebuilt
> node install.js
Considering PhantomJS found at /usr/local/phantomjs/bin/phantomjs
Found PhantomJS at /usr/local/phantomjs/bin/phantomjs ...verifying
Writing location.js file
PhantomJS is already installed on PATH at /usr/local/phantomjs/bin/phantomjs
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN qunit-reporter-junit@1.1.1 requires a peer of qunitjs@* but none is installed. You must install peer dependencies yourself.
added 336 packages from 231 contributors and audited 1370 packages in 8.512s
found 6 vulnerabilities (1 low, 1 moderate, 4 high)
  run `npm audit fix` to fix them, or `npm audit` for details
> open-location-code@20181203.0.0 test /home/travis/build/google/open-location-code/js
> cd test && gulp
fs.js:27
const { Math, Object, Reflect } = primordials;
                                  ^
ReferenceError: primordials is not defined
    at fs.js:27:35
    at req_ (/home/travis/build/google/open-location-code/js/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/home/travis/build/google/open-location-code/js/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/home/travis/build/google/open-location-code/js/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:759:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:770:10)
    at Module.load (internal/modules/cjs/loader.js:628:32)
    at Function.Module._load (internal/modules/cjs/loader.js:555:12)
    at Module.require (internal/modules/cjs/loader.js:666:19)
    at require (internal/modules/cjs/helpers.js:16:16)
npm ERR! Test failed.  See above for more details.
The command "cd js && npm install && npm test" exited with 1.
```

Updating gulp to 4.0.0, gulp-qunit to 2.0.0 and removing the explicit dependency on gulp-util.