### PR TITLE
Update WORKSPACE to support Bazel 0.24

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,8 +2,8 @@
 startup --host_jvm_args=-Xms500m
 startup --host_jvm_args=-Xmx500m
 startup --host_jvm_args=-XX:-UseParallelGC
-build --local_resources=400,2,1.0
-build --worker_max_instances=2
+# build --local_resources=400,2,1.0
+build --worker_max_instances=auto
 
 # Setting to false will cause Bazel to use local JDK. This can cause the
 # build to fail if it is not version 9.

--- a/.bazelrc
+++ b/.bazelrc
@@ -5,9 +5,9 @@ startup --host_jvm_args=-XX:-UseParallelGC
 build --local_resources=400,2,1.0
 build --worker_max_instances=2
 
-# Makes Protocol Buffers build 2x faster.
-# See https://github.com/bazelbuild/rules_closure#tips
-build --distinct_host_configuration=false
+# Setting to false will cause Bazel to use local JDK. This can cause the
+# build to fail if it is not version 9.
+build --distinct_host_configuration=true
 
 # Configure tests - increase timeout, print everything and timeout warnings
 test --verbose_failures --test_output=all --test_verbose_timeout_warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,17 @@ matrix:
     #
     - language: c
       env: OLC_PATH=js/closure
+      before_cache:
+        # Do not save the Bazel installation, reinstall each time, it fails to install
+        # if the installation is in the cache.
+        - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
       cache:
+        # Increase the timeout to fetch and unpack the cache.
+        timeout: 1000
         directories:
-          - $HOME/.cache/bazel
+          - ${HOME}/.cache/bazel
       script:
+        - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
         - chmod +x install.sh
         - ./install.sh --user && rm -f install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,11 @@ matrix:
         # Do not save the Bazel installation, reinstall each time, it fails to install
         # if the installation is in the cache.
         - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
-      cache: false
+      cache:
         # Increase the timeout to fetch and unpack the cache.
-        #timeout: 1000
-        #directories:
-        #  - ${HOME}/.cache/bazel
+        timeout: 1000
+        directories:
+          - ${HOME}/.cache/bazel
       script:
         - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - language: cpp
       env: OLC_PATH=cpp
       script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.14.0/bazel-0.14.0-installer-linux-x86_64.sh"
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
         - chmod +x install.sh
         - ./install.sh --user && rm -f install.sh
         - ~/bin/bazel test --test_output=all ${OLC_PATH}:all
@@ -43,7 +43,7 @@ matrix:
       jdk: oraclejdk8
       env: OLC_PATH=java
       script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.14.0/bazel-0.14.0-installer-linux-x86_64.sh"
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
         - chmod +x install.sh
         - ./install.sh --user && rm -f install.sh
         - ~/bin/bazel test --test_output=all ${OLC_PATH}:all
@@ -53,8 +53,11 @@ matrix:
     #
     - language: c
       env: OLC_PATH=js/closure
+      cache:
+        directories:
+          - $HOME/.cache/bazel
       script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.14.0/bazel-0.14.0-installer-linux-x86_64.sh"
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
         - chmod +x install.sh
         - ./install.sh --user && rm -f install.sh
         - ~/bin/bazel test ${OLC_PATH}:all
@@ -71,7 +74,7 @@ matrix:
       python: 2.7
       env: OLC_PATH=python
       script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.14.0/bazel-0.14.0-installer-linux-x86_64.sh"
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
         - chmod +x install.sh
         - ./install.sh --user && rm -f install.sh
         - ~/bin/bazel test --test_output=all ${OLC_PATH}:all
@@ -81,7 +84,7 @@ matrix:
       python: 3.4
       env: OLC_PATH=python
       script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.14.0/bazel-0.14.0-installer-linux-x86_64.sh"
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
         - chmod +x install.sh
         - ./install.sh --user && rm -f install.sh
         - ~/bin/bazel test --test_output=all ${OLC_PATH}:all

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,13 @@ matrix:
     # Rust implementation. Lives in rust/
     - language: rust
       env: OLC_PATH=rust
+      # Need to cache the whole `.cargo` directory to keep .crates.toml for cargo-update to work
+      cache:
+        directories:
+          - ${HOME}/.cargo
+      # But don't cache the cargo registry
+      before_cache:
+        - rm -rf ${HOME}/.cargo/registry
       script:
         - cd rust/
         - cargo build --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,16 +50,15 @@ matrix:
 
     # Javascript Closure library implementation. Lives in js/closure, tested with bazel.
     # We use language "c" because bazel will install all the dependencies we need, and we use path "js" for the node_js tests.
-    #
+    # The Bazel configuration is cached. This saves about 3-4 minutes in the tests.
     - language: c
       env: OLC_PATH=js/closure
       before_cache:
-        # Do not save the Bazel installation, reinstall each time, it fails to install
-        # if the installation is in the cache.
+        # Bazel will fail to install if the installation is in the cache.
         - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
       cache:
-        # Increase the timeout to fetch and unpack the cache.
-        timeout: 1000
+        # Set the timeout to fetch and unpack the cache.
+        timeout: 300
         directories:
           - ${HOME}/.cache/bazel
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
         # Do not save the Bazel installation, reinstall each time, it fails to install
         # if the installation is in the cache.
         - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
-      cache:
+      cache: false
         # Increase the timeout to fetch and unpack the cache.
         timeout: 1000
         directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,13 +106,7 @@ matrix:
     # Rust implementation. Lives in rust/
     - language: rust
       env: OLC_PATH=rust
-      # Need to cache the whole `.cargo` directory to keep .crates.toml for cargo-update to work
-      cache:
-        directories:
-          - ${HOME}/.cargo
-      # But don't cache the cargo registry
-      before_cache:
-        - rm -rf ${HOME}/.cargo/registry
+      # Adding caching of .cargo doesn't improve the build/test times.
       script:
         - cd rust/
         - cargo build --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ matrix:
         - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
       cache: false
         # Increase the timeout to fetch and unpack the cache.
-        timeout: 1000
-        directories:
-          - ${HOME}/.cache/bazel
+        #timeout: 1000
+        #directories:
+        #  - ${HOME}/.cache/bazel
       script:
         - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,24 +1,51 @@
 workspace(name = "openlocationcode")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # Include the Google Test framework for C++ testing.
 # See https://github.com/google/googletest
-new_http_archive(
+http_archive(
     name = "gtest",
     url = "https://github.com/google/googletest/archive/release-1.8.0.zip",
     sha256 = "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",
-    build_file = "cpp/gtest.BUILD",
+    build_file = "//cpp:gtest.BUILD",
     strip_prefix = "googletest-release-1.8.0/googletest",
 )
 
 # Include the Bazel Closure rules for javascript testing..
 # See https://github.com/bazelbuild/rules_closure
+# zlib library is required for com_google_protobuf which is loaded by the closure rules.
+# skylib library required by closure rules.
+# Closure rules are pulled in at a specific commit because the current release
+# (0.8.0) doesn't work with Bazel 0.24.1+.
+http_archive(
+    name = "net_zlib",
+    # Original build file reference doesn't work. Fails with:
+    #   Unable to load package for //:third_party/zlib.BUILD: not found. and referenced by '//external:zlib'
+    # build_file = "//:third_party/zlib.BUILD",
+    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+)
+# com_google_protobuf depends on zlib, not net_zlib, so we need to bind.
+bind(
+    name = "zlib",
+    actual = "@net_zlib//:zlib",
+)
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+)
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "a80acb69c63d5f6437b099c111480a4493bad4592015af2127a2f49fb7512d8d",
-    strip_prefix = "rules_closure-0.7.0",
+    sha256 = "1c05fea22c9630cf1047f25d008780756373a60ddd4d2a6993cf9858279c5da6",
+    strip_prefix = "rules_closure-50d3dc9e6d27a5577a0f95708466718825d579f4",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.7.0.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/0.7.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/50d3dc9e6d27a5577a0f95708466718825d579f4.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/50d3dc9e6d27a5577a0f95708466718825d579f4.tar.gz",
     ],
 )
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,7 @@ http_archive(
 # See https://github.com/bazelbuild/rules_closure
 # zlib library is required for com_google_protobuf which is loaded by the closure rules.
 # skylib library required by closure rules.
+# See the Closure WORKSPACE files for the above.
 # Closure rules are pulled in at a specific commit because the current release
 # (0.8.0) doesn't work with Bazel 0.24.1+.
 http_archive(


### PR DESCRIPTION
This now uses the current bazel release, so that tests can be run locally without having to push to travis all the time.

Took the opportunity to set up travis caching for ruby, and for the js/closure project, so it doesn't need to build the bazel dependencies (com_google_protobuf etc) every time. This reduces the time to run the closure tests from over seven minutes to just under two.
