### PR TITLE
Fix error accumulation issue caused by floating point precision

### DIFF
--- a/rust/src/consts.rs
+++ b/rust/src/consts.rs
@@ -49,3 +49,5 @@ pub const GRID_ROWS: f64 = 5f64;
 // Minimum length of a code that can be shortened.
 pub const MIN_TRIMMABLE_CODE_LEN: usize = 6;
 
+// Precision of "gravity" to closest larger integer value.
+pub const NARROW_REGION_PRECISION: f64 = 1e-9;

--- a/rust/src/private.rs
+++ b/rust/src/private.rs
@@ -49,7 +49,7 @@ pub fn prefix_by_reference(pt: Point<f64>, code_length: usize) -> String {
     code
 }
 
-// Apply "gravity" towards closest integer value, if current value is closer that given threshold.
+// Apply "gravity" towards closest integer value, if current value is closer than given threshold.
 // This is a way to compensate aggregated error caused by floating point precision restriction.
 fn near(value: f64, error: f64) -> f64 {
     let target = (value + error).trunc();


### PR DESCRIPTION
The error compensation is applied with precision of 1e-9, seems precise enough for existing code length.

https://github.com/google/open-location-code/issues/317