### PR TITLE
Add benchmarks to Java

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -6,6 +6,18 @@ java_library(
 )
 
 java_test(
+    name = "BenchmarkTest",
+    size = "small",
+    srcs = [
+        "src/test/java/com/google/openlocationcode/BenchmarkTest.java",
+    ],
+    test_class = "com.google.openlocationcode.BenchmarkTest",
+    deps = [
+        ":openlocationcode",
+    ],
+)
+
+java_test(
     name = "DecodingTest",
     size = "small",
     srcs = [

--- a/java/src/test/java/com/google/openlocationcode/BenchmarkTest.java
+++ b/java/src/test/java/com/google/openlocationcode/BenchmarkTest.java
@@ -1,0 +1,71 @@
+package com.google.openlocationcode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests encoding and decoding between Open Location Code and latitude/longitude pair. */
+@RunWith(JUnit4.class)
+public class BenchmarkTest {
+
+  public static final int LOOPS = 1000000;
+  
+  public static Random generator = new Random();
+  
+  private static class TestData {
+
+    private final double latitude;
+    private final double longitude;
+    private final int length;
+    private final String code;
+
+    public TestData() {
+      this.latitude = generator.nextDouble() * 180 - 90;
+      this.longitude = generator.nextDouble() * 360 - 180;
+      int length = generator.nextInt(11) + 4;
+      if (length < 10 && length % 2 == 1) {
+        length += 1;
+      }
+      this.length = length;
+      this.code = OpenLocationCode.encode(this.latitude, this.longitude, this.length);
+    }
+  }
+
+  private final List<TestData> testDataList = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    testDataList.clear();
+    for (int i = 0; i < LOOPS; i++) {
+      testDataList.add(new TestData());
+    }
+  }
+
+  @Test
+  public void benchmarkEncode() {
+    long start = System.nanoTime();
+    for (TestData testData : testDataList) {
+      OpenLocationCode.encode(testData.latitude, testData.longitude, testData.length);
+    }
+    long microsecs = (System.nanoTime() - start) / 1000;
+    
+    System.out.printf("Encode %d loops in %d usecs, %.3f usec per call\n", LOOPS, microsecs, (double)microsecs / LOOPS);
+  }
+
+  @Test
+  public void benchmarkDecode() {
+    long start = System.nanoTime();
+    for (TestData testData : testDataList) {
+      OpenLocationCode.decode(testData.code);
+    }
+    long microsecs = (System.nanoTime() - start) / 1000;
+    
+    System.out.printf("Decode %d loops in %d usecs, %.3f usec per call\n", LOOPS, microsecs, (double)microsecs / LOOPS);
+  }
+}

--- a/java/src/test/java/com/google/openlocationcode/BenchmarkTest.java
+++ b/java/src/test/java/com/google/openlocationcode/BenchmarkTest.java
@@ -3,21 +3,19 @@ package com.google.openlocationcode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests encoding and decoding between Open Location Code and latitude/longitude pair. */
+/** Benchmark the encode and decode methods. */
 @RunWith(JUnit4.class)
 public class BenchmarkTest {
 
   public static final int LOOPS = 1000000;
-  
+
   public static Random generator = new Random();
-  
+
   private static class TestData {
 
     private final double latitude;
@@ -54,8 +52,10 @@ public class BenchmarkTest {
       OpenLocationCode.encode(testData.latitude, testData.longitude, testData.length);
     }
     long microsecs = (System.nanoTime() - start) / 1000;
-    
-    System.out.printf("Encode %d loops in %d usecs, %.3f usec per call\n", LOOPS, microsecs, (double)microsecs / LOOPS);
+
+    System.out.printf(
+        "Encode %d loops in %d usecs, %.3f usec per call\n",
+        LOOPS, microsecs, (double) microsecs / LOOPS);
   }
 
   @Test
@@ -65,7 +65,9 @@ public class BenchmarkTest {
       OpenLocationCode.decode(testData.code);
     }
     long microsecs = (System.nanoTime() - start) / 1000;
-    
-    System.out.printf("Decode %d loops in %d usecs, %.3f usec per call\n", LOOPS, microsecs, (double)microsecs / LOOPS);
+
+    System.out.printf(
+        "Decode %d loops in %d usecs, %.3f usec per call\n",
+        LOOPS, microsecs, (double) microsecs / LOOPS);
   }
 }

--- a/java/src/test/java/com/google/openlocationcode/PrecisionTest.java
+++ b/java/src/test/java/com/google/openlocationcode/PrecisionTest.java
@@ -8,28 +8,30 @@ import org.junit.runners.JUnit4;
 /** Tests size of rectangles defined by open location codes of various size. */
 @RunWith(JUnit4.class)
 public class PrecisionTest {
+  
+  private static final double epsilon = 1e-10;
 
   @Test
   public void testWidthInDegrees() {
-    Assert.assertEquals(new OpenLocationCode("67000000+").decode().getLongitudeWidth(), 20., 0);
-    Assert.assertEquals(new OpenLocationCode("67890000+").decode().getLongitudeWidth(), 1., 0);
-    Assert.assertEquals(new OpenLocationCode("6789CF00+").decode().getLongitudeWidth(), 0.05, 0);
-    Assert.assertEquals(new OpenLocationCode("6789CFGH+").decode().getLongitudeWidth(), 0.0025, 0);
+    Assert.assertEquals(new OpenLocationCode("67000000+").decode().getLongitudeWidth(), 20., epsilon);
+    Assert.assertEquals(new OpenLocationCode("67890000+").decode().getLongitudeWidth(), 1., epsilon);
+    Assert.assertEquals(new OpenLocationCode("6789CF00+").decode().getLongitudeWidth(), 0.05, epsilon);
+    Assert.assertEquals(new OpenLocationCode("6789CFGH+").decode().getLongitudeWidth(), 0.0025, epsilon);
     Assert.assertEquals(
-        new OpenLocationCode("6789CFGH+JM").decode().getLongitudeWidth(), 0.000125, 0);
+        new OpenLocationCode("6789CFGH+JM").decode().getLongitudeWidth(), 0.000125, epsilon);
     Assert.assertEquals(
-        new OpenLocationCode("6789CFGH+JMP").decode().getLongitudeWidth(), 0.00003125, 0);
+        new OpenLocationCode("6789CFGH+JMP").decode().getLongitudeWidth(), 0.00003125, epsilon);
   }
 
   @Test
   public void testHeightInDegrees() {
-    Assert.assertEquals(new OpenLocationCode("67000000+").decode().getLatitudeHeight(), 20., 0);
-    Assert.assertEquals(new OpenLocationCode("67890000+").decode().getLatitudeHeight(), 1., 0);
-    Assert.assertEquals(new OpenLocationCode("6789CF00+").decode().getLatitudeHeight(), 0.05, 0);
-    Assert.assertEquals(new OpenLocationCode("6789CFGH+").decode().getLatitudeHeight(), 0.0025, 0);
+    Assert.assertEquals(new OpenLocationCode("67000000+").decode().getLatitudeHeight(), 20., epsilon);
+    Assert.assertEquals(new OpenLocationCode("67890000+").decode().getLatitudeHeight(), 1., epsilon);
+    Assert.assertEquals(new OpenLocationCode("6789CF00+").decode().getLatitudeHeight(), 0.05, epsilon);
+    Assert.assertEquals(new OpenLocationCode("6789CFGH+").decode().getLatitudeHeight(), 0.0025, epsilon);
     Assert.assertEquals(
-        new OpenLocationCode("6789CFGH+JM").decode().getLatitudeHeight(), 0.000125, 0);
+        new OpenLocationCode("6789CFGH+JM").decode().getLatitudeHeight(), 0.000125, epsilon);
     Assert.assertEquals(
-        new OpenLocationCode("6789CFGH+JMP").decode().getLatitudeHeight(), 0.000025, 0);
+        new OpenLocationCode("6789CFGH+JMP").decode().getLatitudeHeight(), 0.000025, epsilon);
   }
 }


### PR DESCRIPTION
Adds a benchmark test that calls the encoding and decoding functions and outputs the durations.

This helps identify if changes have impacted performance.

Also adds an epsilon into the precision tests.