### PR TITLE
Enable immutable string literals in Ruby

### DIFF
--- a/ruby/lib/plus_codes.rb
+++ b/ruby/lib/plus_codes.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 # Plus+Codes is a Ruby implementation of Google Open Location Code (Plus Codes).
 #
 # @author We-Ming Wu
 module PlusCodes
   # The character set used to encode coordinates.
-  CODE_ALPHABET = '23456789CFGHJMPQRVWX'.freeze
+  CODE_ALPHABET = '23456789CFGHJMPQRVWX'
 
   # The character used to pad a code
-  PADDING = '0'.freeze
+  PADDING = '0'
 
   # A separator used to separate the code into two parts.
-  SEPARATOR = '+'.freeze
+  SEPARATOR = '+'
 
   # The max number of characters can be placed before the separator.
   SEPARATOR_POSITION = 8

--- a/ruby/lib/plus_codes/code_area.rb
+++ b/ruby/lib/plus_codes/code_area.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PlusCodes
   # [CodeArea] contains coordinates of a decoded Open Location Code(Plus+Codes).
   # The coordinates include the latitude and longitude of the lower left and

--- a/ruby/lib/plus_codes/open_location_code.rb
+++ b/ruby/lib/plus_codes/open_location_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../plus_codes'
 require_relative '../plus_codes/code_area'
 

--- a/ruby/open-location-code.gemspec
+++ b/ruby/open-location-code.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'

--- a/ruby/test/plus_codes_test.rb
+++ b/ruby/test/plus_codes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test/unit'
 require_relative '../lib/plus_codes/open_location_code'
 


### PR DESCRIPTION
Adding these comments to each file enables immutable string literals - which Ruby is working towards for Ruby 3.0.

This was identified by the [Rubocop](https://github.com/rubocop-hq/rubocop) checks failing. This was due to the fact that their release 0.69.0 turned this check on always, instead of optionally or off or something as part of their migration off Ruby 2.2.