### PR TITLE
Fix floating point tests in Rust implementation 

### DIFF
--- a/rust/src/consts.rs
+++ b/rust/src/consts.rs
@@ -2,7 +2,7 @@
 pub const SEPARATOR: char = '+';
 
 // The number of characters to place before the separator.
-pub const SEPARATOR_POSITION: usize = 8;
+pub const SEPARATOR_POSITION: i64 = 8;
 
 // The character used to pad codes.
 pub const PADDING_CHAR: char = '0';
@@ -15,7 +15,7 @@ pub const CODE_ALPHABET: [char; 20] = [
 ];
 
 // The base to use to convert numbers to/from.
-pub const ENCODING_BASE: f64 = 20f64;
+pub const ENCODING_BASE: i64 = 20;
 
 // The maximum value for latitude in degrees.
 pub const LATITUDE_MAX: f64 = 90f64;
@@ -23,13 +23,16 @@ pub const LATITUDE_MAX: f64 = 90f64;
 // The maximum value for longitude in degrees.
 pub const LONGITUDE_MAX: f64 = 180f64;
 
+// Maximum number of digits to process for plus codes.
+pub const MAX_CODE_LENGTH: i64 = 15;
+
 // Maximum code length using lat/lng pair encoding. The area of such a
 // code is approximately 13x13 meters (at the equator), and should be suitable
 // for identifying buildings. This excludes prefix and separator characters.
-pub const PAIR_CODE_LENGTH: usize = 10;
+pub const PAIR_CODE_LENGTH: i64 = 10;
 
-// Maximum number of digits to process for plus codes.
-pub const MAX_CODE_LENGTH: usize = 15;
+// Digits in the grid encoding..
+pub const GRID_CODE_LENGTH: i64 = 5;
 
 // The resolution values in degrees for each position in the lat/lng pair
 // encoding. These give the place value of each position, and therefore the
@@ -37,13 +40,10 @@ pub const MAX_CODE_LENGTH: usize = 15;
 pub const PAIR_RESOLUTIONS: [f64; 5] = [20.0f64, 1.0f64, 0.05f64, 0.0025f64, 0.000125f64];
 
 // Number of columns in the grid refinement method.
-pub const GRID_COLUMNS: f64 = 4f64;
+pub const GRID_COLUMNS: i64 = 4;
 
 // Number of rows in the grid refinement method.
-pub const GRID_ROWS: f64 = 5f64;
+pub const GRID_ROWS: i64 = 5;
 
 // Minimum length of a code that can be shortened.
-pub const MIN_TRIMMABLE_CODE_LEN: usize = 6;
-
-// Precision of "gravity" to closest larger integer value.
-pub const NARROW_REGION_PRECISION: f64 = 1e-9;
+pub const MIN_TRIMMABLE_CODE_LEN: i64 = 6;

--- a/rust/src/consts.rs
+++ b/rust/src/consts.rs
@@ -2,7 +2,7 @@
 pub const SEPARATOR: char = '+';
 
 // The number of characters to place before the separator.
-pub const SEPARATOR_POSITION: i64 = 8;
+pub const SEPARATOR_POSITION: usize = 8;
 
 // The character used to pad codes.
 pub const PADDING_CHAR: char = '0';
@@ -15,7 +15,7 @@ pub const CODE_ALPHABET: [char; 20] = [
 ];
 
 // The base to use to convert numbers to/from.
-pub const ENCODING_BASE: i64 = 20;
+pub const ENCODING_BASE: usize = 20;
 
 // The maximum value for latitude in degrees.
 pub const LATITUDE_MAX: f64 = 90f64;
@@ -24,15 +24,15 @@ pub const LATITUDE_MAX: f64 = 90f64;
 pub const LONGITUDE_MAX: f64 = 180f64;
 
 // Maximum number of digits to process for plus codes.
-pub const MAX_CODE_LENGTH: i64 = 15;
+pub const MAX_CODE_LENGTH: usize = 15;
 
 // Maximum code length using lat/lng pair encoding. The area of such a
 // code is approximately 13x13 meters (at the equator), and should be suitable
 // for identifying buildings. This excludes prefix and separator characters.
-pub const PAIR_CODE_LENGTH: i64 = 10;
+pub const PAIR_CODE_LENGTH: usize = 10;
 
 // Digits in the grid encoding..
-pub const GRID_CODE_LENGTH: i64 = 5;
+pub const GRID_CODE_LENGTH: usize = 5;
 
 // The resolution values in degrees for each position in the lat/lng pair
 // encoding. These give the place value of each position, and therefore the
@@ -40,10 +40,10 @@ pub const GRID_CODE_LENGTH: i64 = 5;
 pub const PAIR_RESOLUTIONS: [f64; 5] = [20.0f64, 1.0f64, 0.05f64, 0.0025f64, 0.000125f64];
 
 // Number of columns in the grid refinement method.
-pub const GRID_COLUMNS: i64 = 4;
+pub const GRID_COLUMNS: usize = 4;
 
 // Number of rows in the grid refinement method.
-pub const GRID_ROWS: i64 = 5;
+pub const GRID_ROWS: usize = 5;
 
 // Minimum length of a code that can be shortened.
-pub const MIN_TRIMMABLE_CODE_LEN: i64 = 6;
+pub const MIN_TRIMMABLE_CODE_LEN: usize = 6;

--- a/rust/src/consts.rs
+++ b/rust/src/consts.rs
@@ -47,3 +47,25 @@ pub const GRID_ROWS: usize = 5;
 
 // Minimum length of a code that can be shortened.
 pub const MIN_TRIMMABLE_CODE_LEN: usize = 6;
+
+// What to multiple latitude degrees by to get an integer value. There are three pairs representing
+// decimal digits, and five digits in the grid.
+pub const LAT_INTEGER_MULTIPLIER: i64 = (ENCODING_BASE
+    * ENCODING_BASE
+    * ENCODING_BASE
+    * GRID_ROWS
+    * GRID_ROWS
+    * GRID_ROWS
+    * GRID_ROWS
+    * GRID_ROWS) as i64;
+
+// What to multiple longitude degrees by to get an integer value. There are three pairs representing
+// decimal digits, and five digits in the grid.
+pub const LNG_INTEGER_MULTIPLIER: i64 = (ENCODING_BASE
+    * ENCODING_BASE
+    * ENCODING_BASE
+    * GRID_COLUMNS
+    * GRID_COLUMNS
+    * GRID_COLUMNS
+    * GRID_COLUMNS
+    * GRID_COLUMNS) as i64;

--- a/rust/src/interface.rs
+++ b/rust/src/interface.rs
@@ -118,17 +118,18 @@ pub fn encode(pt: Point<f64>, code_length: usize) -> String {
     // Convert to integers.
     let mut lat_val = (((lat + LATITUDE_MAX) * 2.5e7f64 * 1e6).round() / 1e6f64) as i64;
     let mut lng_val = (((lng + LONGITUDE_MAX) * 8.192e6f64 * 1e6).round() / 1e6f64) as i64;
+    //let mut lat_val = ((lat + LATITUDE_MAX) * 8.192e6f64) as i64;
     //let mut lng_val = ((lng + LONGITUDE_MAX) * 8.192e6f64) as i64;
     
     let mut rev_code = String::with_capacity(trimmed_code_length + 1);
     
     if code_length > PAIR_CODE_LENGTH {
       for _i in 0..GRID_CODE_LENGTH {
-        let lat_digit = lat_val % GRID_ROWS;
+        let lat_digit = lat_val % GRID_ROWS as i64;
         let lng_digit = lng_val % GRID_COLUMNS as i64;
         let ndx = (lat_digit * GRID_COLUMNS as i64 + lng_digit) as usize;
         rev_code.push(CODE_ALPHABET[ndx]);
-        lat_val /= GRID_ROWS;
+        lat_val /= GRID_ROWS as i64;
         lng_val /= GRID_COLUMNS as i64;
       }
     } else {
@@ -183,24 +184,23 @@ pub fn decode(_code: &str) -> Result<CodeArea, String> {
 
     let mut lat = -LATITUDE_MAX;
     let mut lng = -LONGITUDE_MAX;
-    let mut lat_res: i64 = ENCODING_BASE * ENCODING_BASE;
-    let mut lng_res: i64 = ENCODING_BASE * ENCODING_BASE;
+    let mut lat_res: f64 = (ENCODING_BASE * ENCODING_BASE) as f64;
+    let mut lng_res: f64 = lat_res;
 
     for (idx, chr) in code.chars().enumerate() {
         if idx < PAIR_CODE_LENGTH {
             if idx % 2 == 0 {
-                lat_res /= ENCODING_BASE;
+                lat_res /= ENCODING_BASE as f64;
                 lat += lat_res * code_value(chr) as f64;
             } else {
-                lng_res /= ENCODING_BASE;
+                lng_res /= ENCODING_BASE as f64;
                 lng += lng_res * code_value(chr) as f64;
             }
         } else if idx < MAX_CODE_LENGTH {
-            lat_res /= GRID_ROWS;
-            lng_res /= GRID_COLUMNS;
-            lat += lat_res * (code_value(chr) as f64 / GRID_COLUMNS).trunc();
-
-            lng += lng_res * (code_value(chr) as f64 % GRID_COLUMNS);
+            lat_res /= GRID_ROWS as f64;
+            lng_res /= GRID_COLUMNS as f64;
+            lat += lat_res * (code_value(chr) as f64 / GRID_COLUMNS as f64).trunc();
+            lng += lng_res * (code_value(chr) % GRID_COLUMNS) as f64;
         }
     }
     Ok(CodeArea::new(

--- a/rust/src/interface.rs
+++ b/rust/src/interface.rs
@@ -1,15 +1,16 @@
 use geo::Point;
+use std::cmp;
 
 use codearea::CodeArea;
 
 use consts::{
-    CODE_ALPHABET, ENCODING_BASE, GRID_COLUMNS, GRID_ROWS, LATITUDE_MAX, LONGITUDE_MAX,
+    CODE_ALPHABET, ENCODING_BASE, GRID_CODE_LENGTH, GRID_COLUMNS, GRID_ROWS, LATITUDE_MAX, LONGITUDE_MAX,
     MAX_CODE_LENGTH, MIN_TRIMMABLE_CODE_LEN, PADDING_CHAR, PADDING_CHAR_STR, PAIR_CODE_LENGTH,
     PAIR_RESOLUTIONS, SEPARATOR, SEPARATOR_POSITION,
 };
 
 use private::{
-    clip_latitude, code_value, compute_latitude_precision, narrow_region, normalize_longitude,
+    clip_latitude, code_value, compute_latitude_precision, normalize_longitude,
     prefix_by_reference,
 };
 
@@ -104,47 +105,62 @@ pub fn is_full(_code: &str) -> bool {
 /// 11 or 12 are probably the limit of useful codes.
 pub fn encode(pt: Point<f64>, code_length: usize) -> String {
     let mut lat = clip_latitude(pt.lat());
-    let mut lng = normalize_longitude(pt.lng());
+    let lng = normalize_longitude(pt.lng());
 
-    let mut trimmed_code_length = code_length;
-    if trimmed_code_length > MAX_CODE_LENGTH {
-        trimmed_code_length = MAX_CODE_LENGTH;
-    }
-
+    let trimmed_code_length = cmp::min(code_length, MAX_CODE_LENGTH);
+    
     // Latitude 90 needs to be adjusted to be just less, so the returned code
     // can also be decoded.
     if lat > LATITUDE_MAX || (LATITUDE_MAX - lat) < 1e-10f64 {
         lat -= compute_latitude_precision(trimmed_code_length);
     }
-
-    lat += LATITUDE_MAX;
-    lng += LONGITUDE_MAX;
-
-    let mut code = String::with_capacity(trimmed_code_length + 1);
-    let mut digit = 0;
-    while digit < trimmed_code_length {
-        narrow_region(digit, &mut lat, &mut lng);
-
-        let lat_digit = lat as usize;
-        let lng_digit = lng as usize;
-        if digit < PAIR_CODE_LENGTH {
-            code.push(CODE_ALPHABET[lat_digit]);
-            code.push(CODE_ALPHABET[lng_digit]);
-            digit += 2;
-        } else {
-            code.push(CODE_ALPHABET[4 * lat_digit + lng_digit]);
-            digit += 1;
-        }
-        lat -= lat_digit as f64;
-        lng -= lng_digit as f64;
-        if digit == SEPARATOR_POSITION {
-            code.push(SEPARATOR);
-        }
+    
+    // Convert to integers.
+    let mut lat_val = (((lat + LATITUDE_MAX) * 2.5e7f64 * 1e6).round() / 1e6f64) as i64;
+    let mut lng_val = (((lng + LONGITUDE_MAX) * 8.192e6f64 * 1e6).round() / 1e6f64) as i64;
+    //let mut lng_val = ((lng + LONGITUDE_MAX) * 8.192e6f64) as i64;
+    
+    let mut rev_code = String::with_capacity(trimmed_code_length + 1);
+    
+    if code_length > PAIR_CODE_LENGTH {
+      for _i in 0..GRID_CODE_LENGTH {
+        let lat_digit = lat_val % GRID_ROWS;
+        let lng_digit = lng_val % GRID_COLUMNS as i64;
+        let ndx = (lat_digit * GRID_COLUMNS as i64 + lng_digit) as usize;
+        rev_code.push(CODE_ALPHABET[ndx]);
+        lat_val /= GRID_ROWS;
+        lng_val /= GRID_COLUMNS as i64;
+      }
+    } else {
+      lat_val /= 3125;
+      lng_val /= 1024;
     }
-    if digit < SEPARATOR_POSITION {
-        code.push_str(PADDING_CHAR_STR.repeat(SEPARATOR_POSITION - digit).as_str());
-        code.push(SEPARATOR);
+    let enc_base = ENCODING_BASE as i64;
+    // Compute the pair section of the code.
+    for i in 0..PAIR_CODE_LENGTH / 2 {
+      rev_code.push(CODE_ALPHABET[(lng_val % enc_base) as usize]);
+      rev_code.push(CODE_ALPHABET[(lat_val % enc_base) as usize]);
+      lat_val /= enc_base;
+      lng_val /= enc_base;
+      // If we are at the separator position, add the separator.
+      if i == 0 {
+        rev_code.push(SEPARATOR);
+      }
     }
+    // Reverse the characters in the code.
+    let mut code = rev_code.chars().rev().collect::<String>();
+
+    // If we need to pad the code, replace some of the digits.
+    if code_length < SEPARATOR_POSITION {
+      code = code.chars().take(code_length).collect();
+      code.push_str(
+          PADDING_CHAR_STR.repeat(SEPARATOR_POSITION - code_length).as_str()
+      );
+      code.push(SEPARATOR);
+    } else {
+      code = code.chars().take(code_length + 1).collect();
+    }
+    
     code
 }
 
@@ -167,8 +183,8 @@ pub fn decode(_code: &str) -> Result<CodeArea, String> {
 
     let mut lat = -LATITUDE_MAX;
     let mut lng = -LONGITUDE_MAX;
-    let mut lat_res = ENCODING_BASE * ENCODING_BASE;
-    let mut lng_res = ENCODING_BASE * ENCODING_BASE;
+    let mut lat_res: i64 = ENCODING_BASE * ENCODING_BASE;
+    let mut lng_res: i64 = ENCODING_BASE * ENCODING_BASE;
 
     for (idx, chr) in code.chars().enumerate() {
         if idx < PAIR_CODE_LENGTH {

--- a/rust/src/private.rs
+++ b/rust/src/private.rs
@@ -1,6 +1,5 @@
 use consts::{
-    CODE_ALPHABET, ENCODING_BASE, GRID_ROWS, LATITUDE_MAX, LONGITUDE_MAX,
-    PAIR_CODE_LENGTH,
+    CODE_ALPHABET, ENCODING_BASE, GRID_ROWS, LATITUDE_MAX, LONGITUDE_MAX, PAIR_CODE_LENGTH,
 };
 
 use interface::encode;
@@ -33,7 +32,8 @@ pub fn compute_latitude_precision(code_length: usize) -> f64 {
     if code_length <= PAIR_CODE_LENGTH {
         return (ENCODING_BASE as f64).powf((code_length as f64 / -2f64 + 2f64).floor());
     }
-    (ENCODING_BASE as f64).powf(-3f64) / GRID_ROWS.pow((code_length - PAIR_CODE_LENGTH) as u32) as f64
+    (ENCODING_BASE as f64).powf(-3f64)
+        / GRID_ROWS.pow((code_length - PAIR_CODE_LENGTH) as u32) as f64
 }
 
 pub fn prefix_by_reference(pt: Point<f64>, code_length: usize) -> String {

--- a/rust/src/private.rs
+++ b/rust/src/private.rs
@@ -1,6 +1,6 @@
 use consts::{
-    CODE_ALPHABET, ENCODING_BASE, GRID_COLUMNS, GRID_ROWS, LATITUDE_MAX, LONGITUDE_MAX,
-    NARROW_REGION_PRECISION, PAIR_CODE_LENGTH,
+    CODE_ALPHABET, ENCODING_BASE, GRID_ROWS, LATITUDE_MAX, LONGITUDE_MAX,
+    PAIR_CODE_LENGTH,
 };
 
 use interface::encode;
@@ -31,9 +31,9 @@ pub fn clip_latitude(latitude_degrees: f64) -> f64 {
 
 pub fn compute_latitude_precision(code_length: usize) -> f64 {
     if code_length <= PAIR_CODE_LENGTH {
-        return ENCODING_BASE.powf((code_length as f64 / -2f64 + 2f64).floor());
+        return (ENCODING_BASE as f64).powf((code_length as f64 / -2f64 + 2f64).floor());
     }
-    ENCODING_BASE.powi(-3i32) / GRID_ROWS.powf(code_length as f64 - PAIR_CODE_LENGTH as f64)
+    (ENCODING_BASE as f64).powf(-3f64) / GRID_ROWS.pow((code_length - PAIR_CODE_LENGTH) as u32) as f64
 }
 
 pub fn prefix_by_reference(pt: Point<f64>, code_length: usize) -> String {
@@ -47,47 +47,4 @@ pub fn prefix_by_reference(pt: Point<f64>, code_length: usize) -> String {
     );
     code.drain(code_length..);
     code
-}
-
-// Apply "gravity" towards closest integer value, if current value is closer than given threshold.
-// This is a way to compensate aggregated error caused by floating point precision restriction.
-fn near(value: f64, error: f64) -> f64 {
-    let target = (value + error).trunc();
-    if value.trunc() != target {
-        target
-    } else {
-        value
-    }
-}
-
-pub fn narrow_region(digit: usize, lat: &mut f64, lng: &mut f64) {
-    if digit == 0 {
-        *lat /= ENCODING_BASE;
-        *lng /= ENCODING_BASE;
-    } else if digit < PAIR_CODE_LENGTH {
-        *lat *= ENCODING_BASE;
-        *lng *= ENCODING_BASE;
-    } else {
-        *lat *= GRID_ROWS;
-        *lng *= GRID_COLUMNS
-    }
-    *lat = near(*lat, NARROW_REGION_PRECISION);
-    *lng = near(*lng, NARROW_REGION_PRECISION);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn near_applied() {
-        let value = 3.0f64 - NARROW_REGION_PRECISION * 2.;
-        assert_eq!(near(value, NARROW_REGION_PRECISION), value);
-    }
-
-    #[test]
-    fn near_not_applied() {
-        let value = 3.0f64 - NARROW_REGION_PRECISION;
-        assert_eq!(near(value, NARROW_REGION_PRECISION), 3.0f64);
-    }
 }


### PR DESCRIPTION
Fix final floating point tests in rust implementation by using integer operations for encode and decode.