### PR TITLE
Fix: Clip lat and lng to prevent DoS attacks using very large values

### DIFF
--- a/go/encode.go
+++ b/go/encode.go
@@ -53,7 +53,11 @@ func Encode(lat, lng float64, codeLen int) string {
 	} else if codeLen > maxCodeLen {
 		codeLen = maxCodeLen
 	}
-	lat, lng = clipLatitude(lat), normalizeLng(lng)
+
+	// Clip lat and lng to prevent DoS attacks using very large values (100% CPU)
+	lat, lng = clipLatitude(lat), clipLongitude(lng)
+	lng = normalizeLng(lng)
+
 	// Latitude 90 needs to be adjusted to be just less, so the returned code
 	// can also be decoded.
 	if lat == latMax {

--- a/go/olc.go
+++ b/go/olc.go
@@ -231,6 +231,19 @@ func clipLatitude(lat float64) float64 {
 	return lat
 }
 
+// clipLongitude forces the longitude into the valid range.
+func clipLongitude(lng float64) float64 {
+	// clip at lngMax * 2 to avoid failing tests,
+	// see test_data/encoding.csv line 27
+	if lng > lngMax*2 {
+		return lngMax
+	}
+	if lng < -lngMax*2 {
+		return -lngMax
+	}
+	return lng
+}
+
 func normalizeLat(value float64) float64 {
 	return normalize(value, latMax)
 }

--- a/go/olc_test.go
+++ b/go/olc_test.go
@@ -132,13 +132,27 @@ func TestCheck(t *testing.T) {
 }
 
 func TestEncode(t *testing.T) {
-	for i, elt := range encoding {
-		got := Encode(elt.lat, elt.lng, elt.length)
-		if got != elt.code {
-			t.Errorf("%d. got %q for (%v,%v,%d), wanted %q.", i, got, elt.lat, elt.lng, elt.length, elt.code)
-			t.FailNow()
+	t.Run("csv", func(t *testing.T) {
+		for i, elt := range encoding {
+			got := Encode(elt.lat, elt.lng, elt.length)
+			if got != elt.code {
+				t.Fatalf("%d. got %q for (%v,%v,%d), wanted %q.", i, got, elt.lat, elt.lng, elt.length, elt.code)
+			}
 		}
-	}
+	})
+
+	t.Run("clip", func(t *testing.T) {
+		length := 11
+		lat := 50000000000000.0
+		lng := 100000000000000.0
+		code := "C2X2X2X2+X2R"
+
+		got := Encode(lat, lng, length)
+
+		if got != code {
+			t.Fatalf("got %q for (%v,%v,%d), wanted %q.", got, lat, lng, length, code)
+		}
+	})
 }
 
 func TestDecode(t *testing.T) {


### PR DESCRIPTION
Unclear why longitude should not be clipped, although existing test cases use values that are out of range (+-180). Normalize gets stuck for me with large numbers... 100% CPU load, not enough time to test for how long. My Go version is 1.13.4 (OS X and Linux on a MacBook).

Signed-off-by: Michael Mayer <michael@liquidbytes.net>