### PR TITLE
Add Python 3.7, 3.8 and openjdk>8 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
         - go test ./tile_server/gridserver -v
 
     # Java implementation. Lives in java/, tested with bazel and maven.
+    # Only testing LTS releases of oraclejdk
+    # Ref: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html
     - language: java
       jdk: oraclejdk8
       # Java 8 requires dist: trusty
@@ -89,45 +91,49 @@ matrix:
         - ./install.sh --user && rm -f install.sh
         - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
 
-    # Java implementation. Lives in java/, tested with bazel and maven.
-    - language: java
-      jdk: oraclejdk11
-      env: OLC_PATH=java
-      script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
-        - chmod +x install.sh
-        - ./install.sh --user && rm -f install.sh
-        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
-
-    # Java implementation. Lives in java/, tested with bazel and maven.
-    - language: java
-      jdk: openjdk11
-      env: OLC_PATH=java
-      script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
-        - chmod +x install.sh
-        - ./install.sh --user && rm -f install.sh
-        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
-
-    # Java implementation. Lives in java/, tested with bazel and maven.
-    - language: java
-      jdk: openjdk12
-      env: OLC_PATH=java
-      script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
-        - chmod +x install.sh
-        - ./install.sh --user && rm -f install.sh
-        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
-
-    # Java implementation. Lives in java/, tested with bazel and maven.
-    - language: java
-      jdk: openjdk13
-      env: OLC_PATH=java
-      script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
-        - chmod +x install.sh
-        - ./install.sh --user && rm -f install.sh
-        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+    ## TODO: Fix java11+ issues with javadoc archive
+    ## Ref: https://travis-ci.org/google/open-location-code/jobs/630142096#L2404
+    # # Java implementation. Lives in java/, tested with bazel and maven.
+    # # Only testing LTS releases of oraclejdk
+    # # Ref: https://www.oracle.com/technetwork/java/java-se-support-roadmap.html
+    # - language: java
+    #   jdk: oraclejdk11
+    #   env: OLC_PATH=java
+    #   script:
+    #     - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+    #     - chmod +x install.sh
+    #     - ./install.sh --user && rm -f install.sh
+    #     - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+    #
+    # # Java implementation. Lives in java/, tested with bazel and maven.
+    # - language: java
+    #   jdk: openjdk11
+    #   env: OLC_PATH=java
+    #   script:
+    #     - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+    #     - chmod +x install.sh
+    #     - ./install.sh --user && rm -f install.sh
+    #     - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+    #
+    # # Java implementation. Lives in java/, tested with bazel and maven.
+    # - language: java
+    #   jdk: openjdk12
+    #   env: OLC_PATH=java
+    #   script:
+    #     - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+    #     - chmod +x install.sh
+    #     - ./install.sh --user && rm -f install.sh
+    #     - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+    #
+    # # Java implementation. Lives in java/, tested with bazel and maven.
+    # - language: java
+    #   jdk: openjdk13
+    #   env: OLC_PATH=java
+    #   script:
+    #     - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+    #     - chmod +x install.sh
+    #     - ./install.sh --user && rm -f install.sh
+    #     - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
 
     # Javascript Closure library implementation. Lives in js/closure, tested with bazel.
     # We use language "c" because bazel will install all the dependencies we need, and we use path "js" for the node_js tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ matrix:
     # Python implementation. Lives in python/, tested with bazel.
     - language: python
       python: 3.7
+      dist: bionic
       env: OLC_PATH=python
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
@@ -120,6 +121,7 @@ matrix:
     # Python implementation. Lives in python/, tested with bazel.
     - language: python
       python: 3.8
+      dist: bionic
       env: OLC_PATH=python
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ matrix:
     # Java implementation. Lives in java/, tested with bazel and maven.
     - language: java
       jdk: oraclejdk8
-      # Java 8 requires dist: xenial
-      dist: xenial
+      # Java 8 requires dist: trusty
+      dist: trusty
       env: OLC_PATH=java
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
@@ -60,8 +60,8 @@ matrix:
     # Java implementation. Lives in java/, tested with bazel and maven.
     - language: java
       jdk: openjdk8
-      # Java 8 requires dist: xenial
-      dist: xenial
+      # Java 8 requires dist: trusty
+      dist: trusty
       env: OLC_PATH=java
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,31 +71,7 @@ matrix:
 
     # Java implementation. Lives in java/, tested with bazel and maven.
     - language: java
-      jdk: oraclejdk9
-      # Oracle Java 9 requires dist: xenial
-      dist: xenial
-      env: OLC_PATH=java
-      script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
-        - chmod +x install.sh
-        - ./install.sh --user && rm -f install.sh
-        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
-
-    # Java implementation. Lives in java/, tested with bazel and maven.
-    - language: java
       jdk: openjdk9
-      env: OLC_PATH=java
-      script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
-        - chmod +x install.sh
-        - ./install.sh --user && rm -f install.sh
-        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
-
-    # Java implementation. Lives in java/, tested with bazel and maven.
-    - language: java
-      jdk: oraclejdk10
-      # Oracle Java 10 requires dist: xenial
-      dist: xenial
       env: OLC_PATH=java
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
@@ -135,27 +111,7 @@ matrix:
 
     # Java implementation. Lives in java/, tested with bazel and maven.
     - language: java
-      jdk: oraclejdk12
-      env: OLC_PATH=java
-      script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
-        - chmod +x install.sh
-        - ./install.sh --user && rm -f install.sh
-        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
-
-    # Java implementation. Lives in java/, tested with bazel and maven.
-    - language: java
       jdk: openjdk12
-      env: OLC_PATH=java
-      script:
-        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
-        - chmod +x install.sh
-        - ./install.sh --user && rm -f install.sh
-        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
-
-    # Java implementation. Lives in java/, tested with bazel and maven.
-    - language: java
-      jdk: oraclejdk13
       env: OLC_PATH=java
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,28 @@ matrix:
         - ~/bin/bazel test --test_output=all ${OLC_PATH}:all
         - cd ${OLC_PATH} && bash format_check.sh
 
+    # Python implementation. Lives in python/, tested with bazel.
+    - language: python
+      python: 3.7
+      env: OLC_PATH=python
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all
+        - cd ${OLC_PATH} && bash format_check.sh
+
+    # Python implementation. Lives in python/, tested with bazel.
+    - language: python
+      python: 3.8
+      env: OLC_PATH=python
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all
+        - cd ${OLC_PATH} && bash format_check.sh
+
     # Ruby implementation. Lives in ruby/
     - language: ruby
       rvm: 2.6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 # Use sudo: required slows boot time but gives us 7.5GB of ram to prevent Bazel running OOM.
 sudo: required
-dist: trusty
+dist: bionic
 
 matrix:
   include:
@@ -109,7 +109,6 @@ matrix:
     # Python implementation. Lives in python/, tested with bazel.
     - language: python
       python: 3.7
-      dist: bionic
       env: OLC_PATH=python
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
@@ -121,7 +120,6 @@ matrix:
     # Python implementation. Lives in python/, tested with bazel.
     - language: python
       python: 3.8
-      dist: bionic
       env: OLC_PATH=python
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,120 @@ matrix:
     # Java implementation. Lives in java/, tested with bazel and maven.
     - language: java
       jdk: oraclejdk8
+      # Java 8 requires dist: xenial
+      dist: xenial
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: openjdk8
+      # Java 8 requires dist: xenial
+      dist: xenial
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: oraclejdk9
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: openjdk9
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: oraclejdk10
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: openjdk10
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: oraclejdk11
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: openjdk11
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: oraclejdk12
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: openjdk12
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: oraclejdk13
+      env: OLC_PATH=java
+      script:
+        - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
+        - chmod +x install.sh
+        - ./install.sh --user && rm -f install.sh
+        - ~/bin/bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+
+    # Java implementation. Lives in java/, tested with bazel and maven.
+    - language: java
+      jdk: openjdk13
       env: OLC_PATH=java
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,8 @@ matrix:
     # Java implementation. Lives in java/, tested with bazel and maven.
     - language: java
       jdk: oraclejdk9
+      # Oracle Java 9 requires dist: xenial
+      dist: xenial
       env: OLC_PATH=java
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"
@@ -92,6 +94,8 @@ matrix:
     # Java implementation. Lives in java/, tested with bazel and maven.
     - language: java
       jdk: oraclejdk10
+      # Oracle Java 10 requires dist: xenial
+      dist: xenial
       env: OLC_PATH=java
       script:
         - wget -O install.sh "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel-0.24.1-installer-linux-x86_64.sh"


### PR DESCRIPTION
Per https://github.com/google/open-location-code/issues/369#issuecomment-569322868 , Python 3.6 is already tested, however https://github.com/google/open-location-code/issues/369 states:

> the Python module does not work in Python 3.7

So, adding python 3.7 and 3.8, which have some potentially breaking changes, to the build matrix for continuous testing.