### PR TITLE
Update Dart SDK constraint to allow SDK versions up to 3.0.0.

### DIFF
--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -2,5 +2,7 @@ name: open_location_code
 description: Open Location Codes are short, generated codes that can be used like street addresses, for places where street addresses don't exist.
 version: 0.0.1
 homepage: http://openlocationcode.com/
+environment:
+  sdk: '<3.0.0'
 dev_dependencies:
   test: '>=0.12.0'


### PR DESCRIPTION
If the environment constraint is not specified, it automatically means the package only supports Dart SDK < 2.0.0, preventing the library from being used with the most recent Dart version (currently 2.8.3).