### PR TITLE
Fix rubocop offenses

### DIFF
--- a/ruby/open-location-code.gemspec
+++ b/ruby/open-location-code.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*']
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
+  s.required_ruby_version = '>= 2.4.0'
 
   s.add_development_dependency 'test-unit'
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,5 +1,9 @@
 # Override rubocop defaults.
 
+Layout/LineLength:
+  Enabled: true
+  Max: 80
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/ruby/test/plus_codes_test.rb
+++ b/ruby/test/plus_codes_test.rb
@@ -117,18 +117,20 @@ class PlusCodesTest < Test::Unit::TestCase
       @olc.encode(lat, lng, len)
     end
     duration_micros = (Time.now.to_f * 1e6).to_i - start_micros
-    printf("Encode benchmark: %d usec total, %d loops, %f usec per call\n",
-           duration_micros, test_data.length,
-           duration_micros.to_f / test_data.length)
+    printf('Encode benchmark: ')
+    printf("%<total>d usec total, %<loops>d loops, %<percall>f usec per call\n",
+           total: duration_micros, loops: test_data.length,
+           percall: duration_micros.to_f / test_data.length)
 
     start_micros = (Time.now.to_f * 1e6).to_i
     test_data.each do |_, _, _, code|
       @olc.decode(code)
     end
     duration_micros = (Time.now.to_f * 1e6).to_i - start_micros
-    printf("Decode benchmark: %d usec total, %d loops, %f usec per call\n",
-           duration_micros, test_data.length,
-           duration_micros.to_f / test_data.length)
+    printf('Decode benchmark: ')
+    printf("%<total>d usec total, %<loops>d loops, %<percall>f usec per call\n",
+           total: duration_micros, loops: test_data.length,
+           percall: duration_micros.to_f / test_data.length)
   end
 
   def read_csv_lines(csv_file)


### PR DESCRIPTION
Use named references in printf.
Set LineLength to 80 in rubocop config to match project convention and prevent IfUnlessModifier offenses.
Specify required_ruby_version >= 2.4 in gemspec