### PR TITLE
Remove unneeded return statement

### DIFF
--- a/rust/src/interface.rs
+++ b/rust/src/interface.rs
@@ -168,7 +168,7 @@ pub fn encode(pt: Point<f64>, code_length: usize) -> String {
         code = rev_code.chars().rev().take(code_length + 1).collect();
     }
 
-    return code;
+    code
 }
 
 /// Decodes an Open Location Code into the location coordinates.


### PR DESCRIPTION
Remove unneeded return statement from end of function. 
Expressions at end of function are automatically returned
Tests as per travis.yml carried out successfully
Fixes #405 