### PR TITLE
Fix encoding steps for grid digits

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -52,14 +52,14 @@ The following provides an algorithm to encode the values from least significant 
 ### Least significant five digits
 
 This differs from the above method in that each step produces a single character.
-This encodes latitude into base five and longitude into base four, and then multiplies the digits for each position together.
+This encodes latitude into base five and longitude into base four, and then combines the digits for each position together.
 
 The following provides an algorithm to encode the values from least significant digit to most significant digit:
-1. Add 90 to the latiude, multiply the fractional part by 2.5e7 and take the integer part as latitude
-1. Add 180 to the longitude, multiply the fractional part by 8.192e6 and take the integer part as longitude
-1. Multiply the integer part of longitude modulus 4 by the integer part of latitude modulus 5
-1. Prefix the existing code with the symbol with the above value
-1. Divide longitude by four and latitude by five
+1. Add 90 to the latiude, multiply the fractional part by 2.5e7 and take the integer part as latitude.
+1. Add 180 to the longitude, multiply the fractional part by 8.192e6 and take the integer part as longitude.
+1. Take the integer part of latitude modulus 5. Multiply that by 4, and add the integer part of the longitude modulus 4.
+1. Prefix the existing code with the symbol with the above value.
+1. Divide longitude by four and latitude by five.
 1. Repeat from step 2 four more times.
 
 ### Code length


### PR DESCRIPTION
The correct calculation for the least-significant digits is:
  4*(latitude % 5) + (longitude % 4)
This is the formula used in many different implementations:
[C++](https://github.com/google/open-location-code/blob/84f0adbdbfec7b165cdbb419f36cc62b78761533/cpp/openlocationcode.cc#L151)
[Java](https://github.com/google/open-location-code/blob/84f0adbdbfec7b165cdbb419f36cc62b78761533/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java#L223)
[TypeScript](https://github.com/tspoke/typescript-open-location-code/blob/d61f5081a8a830409fee43f0711889c4c6478546/src/open-location-code.ts#L308)

The previous documentation had this incorrect instruction:
  (latitude % 5) * (longitude % 4)