### PR TITLE
Noop: Omit type annotations for local variables. 

### DIFF
--- a/dart/lib/src/open_location_code.dart
+++ b/dart/lib/src/open_location_code.dart
@@ -102,14 +102,14 @@ const _decode = <int>[
 ]; //
 
 bool _matchesPattern(String string, Pattern pattern) =>
-    string.indexOf(pattern) >= 0;
+    string.contains(pattern);
 
 bool isValid(String code) {
   if (code == null || code.length == 1) {
     return false;
   }
 
-  int separatorIndex = code.indexOf(separator);
+  var separatorIndex = code.indexOf(separator);
   // There must be a single separator at an even index and position should be < SEPARATOR_POSITION.
   if (separatorIndex == -1 ||
       separatorIndex != code.lastIndexOf(separator) ||
@@ -268,17 +268,17 @@ String encode(num latitude, num longitude, {int codeLength = pairCodeLength}) {
   // Multiply values by their precision and convert to positive.
   // Force to integers so the division operations will have integer results.
   // Note: Dart requires rounding before truncating to ensure precision!
-  int latVal =
+  var latVal =
       ((latitude + latitudeMax) * finalLatPrecision * 1e6).round() ~/ 1e6;
-  int lngVal =
+  var lngVal =
       ((longitude + longitudeMax) * finalLngPrecision * 1e6).round() ~/ 1e6;
 
   // Compute the grid part of the code if necessary.
   if (codeLength > pairCodeLength) {
     for (var i = 0; i < maxDigitCount - pairCodeLength; i++) {
-      int lat_digit = latVal % gridRows;
-      int lng_digit = lngVal % gridColumns;
-      int ndx = lat_digit * gridColumns + lng_digit;
+      var lat_digit = latVal % gridRows;
+      var lng_digit = lngVal % gridColumns;
+      var ndx = lat_digit * gridColumns + lng_digit;
       code = codeAlphabet[ndx] + code;
       // Note! Integer division.
       latVal ~/= gridRows;

--- a/dart/test/benchmark_test.dart
+++ b/dart/test/benchmark_test.dart
@@ -2,7 +2,6 @@ import 'package:open_location_code/open_location_code.dart' as olc;
 import 'package:test/test.dart';
 import 'dart:math';
 
-
 void main() {
   test('Benchmarking encode and decode', () {
     var now = DateTime.now();

--- a/dart/test/benchmark_test.dart
+++ b/dart/test/benchmark_test.dart
@@ -2,6 +2,7 @@ import 'package:open_location_code/open_location_code.dart' as olc;
 import 'package:test/test.dart';
 import 'dart:math';
 
+
 void main() {
   test('Benchmarking encode and decode', () {
     var now = DateTime.now();

--- a/dart/test/benchmark_test.dart
+++ b/dart/test/benchmark_test.dart
@@ -2,7 +2,7 @@ import 'package:open_location_code/open_location_code.dart' as olc;
 import 'package:test/test.dart';
 import 'dart:math';
 
-main() {
+void main() {
   test('Benchmarking encode and decode', () {
     var now = DateTime.now();
     var random = Random(now.millisecondsSinceEpoch);
@@ -21,12 +21,12 @@ main() {
       olc.decode(code);
       testData.add([lat, lng, length, code]);
     }
-    Stopwatch stopwatch = Stopwatch()..start();
+    var stopwatch = Stopwatch()..start();
     for (var i = 0; i < testData.length; i++) {
       olc.encode(testData[i][0], testData[i][1], codeLength: testData[i][2]);
     }
     var duration = stopwatch.elapsedMicroseconds;
-    print('Encoding benchmark ${testData.length}, duration ${duration} usec, ' +
+    print('Encoding benchmark ${testData.length}, duration ${duration} usec, '
         'average ${duration / testData.length} usec');
 
     stopwatch = Stopwatch()..start();
@@ -34,7 +34,7 @@ main() {
       olc.decode(testData[i][3]);
     }
     duration = stopwatch.elapsedMicroseconds;
-    print('Decoding benchmark ${testData.length}, duration ${duration} usec, ' +
+    print('Decoding benchmark ${testData.length}, duration ${duration} usec, '
         'average ${duration / testData.length} usec');
   });
 }

--- a/dart/test/clip_latitude_test.dart
+++ b/dart/test/clip_latitude_test.dart
@@ -17,7 +17,7 @@
 import 'package:open_location_code/open_location_code.dart' as olc;
 import 'package:test/test.dart';
 
-main() {
+void main() {
   test('Clip latitude test', () {
     expect(olc.clipLatitude(100.0), 90.0);
     expect(olc.clipLatitude(-100.0), -90.0);

--- a/dart/test/compute_precision_test.dart
+++ b/dart/test/compute_precision_test.dart
@@ -1,7 +1,7 @@
 import 'package:open_location_code/open_location_code.dart' as olc;
 import 'package:test/test.dart';
 
-main() {
+void main() {
   test('Compute precision test', () {
     expect(olc.computeLatitudePrecision(10), 0.000125);
     expect(olc.computeLatitudePrecision(11), 0.000025);

--- a/dart/test/decode_test.dart
+++ b/dart/test/decode_test.dart
@@ -19,15 +19,15 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 // code,lat,lng,latLo,lngLo,latHi,lngHi
-checkEncodeDecode(String csvLine) {
-  List<String> elements = csvLine.split(",");
-  String code = elements[0];
+void checkEncodeDecode(String csvLine) {
+  var elements = csvLine.split(',');
+  var code = elements[0];
   num len = int.parse(elements[1]);
   num latLo = double.parse(elements[2]);
   num lngLo = double.parse(elements[3]);
   num latHi = double.parse(elements[4]);
   num lngHi = double.parse(elements[5]);
-  olc.CodeArea codeArea = olc.decode(code);
+  var codeArea = olc.decode(code);
   expect(codeArea.codeLength, equals(len));
   expect(codeArea.south, closeTo(latLo, 0.001));
   expect(codeArea.north, closeTo(latHi, 0.001));
@@ -35,7 +35,7 @@ checkEncodeDecode(String csvLine) {
   expect(codeArea.east, closeTo(lngHi, 0.001));
 }
 
-main() {
+void main() {
   test('Check decode', () {
     csvLinesFromFile('decoding.csv').forEach(checkEncodeDecode);
   });

--- a/dart/test/encode_test.dart
+++ b/dart/test/encode_test.dart
@@ -19,17 +19,17 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 // code,lat,lng,latLo,lngLo,latHi,lngHi
-checkEncodeDecode(String csvLine) {
-  List<String> elements = csvLine.split(",");
+void checkEncodeDecode(String csvLine) {
+  var elements = csvLine.split(',');
   num lat = double.parse(elements[0]);
   num lng = double.parse(elements[1]);
   num len = int.parse(elements[2]);
-  String want = elements[3];
-  String got = olc.encode(lat, lng, codeLength: len);
+  var want = elements[3];
+  var got = olc.encode(lat, lng, codeLength: len);
   expect(got, equals(want));
 }
 
-main() {
+void main() {
   test('Check encode decode', () {
     csvLinesFromFile('encoding.csv').forEach(checkEncodeDecode);
   });

--- a/dart/test/short_code_test.dart
+++ b/dart/test/short_code_test.dart
@@ -19,24 +19,24 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 // full code,lat,lng,shortcode
-checkShortCode(String csvLine) {
-  List<String> elements = csvLine.split(",");
-  String code = elements[0];
+void checkShortCode(String csvLine) {
+  var elements = csvLine.split(',');
+  var code = elements[0];
   num lat = double.parse(elements[1]);
   num lng = double.parse(elements[2]);
-  String shortCode = elements[3];
-  String testType = elements[4];
-  if (testType == "B" || testType == "S") {
-    String short = olc.shorten(code, lat, lng);
+  var shortCode = elements[3];
+  var testType = elements[4];
+  if (testType == 'B' || testType == 'S') {
+    var short = olc.shorten(code, lat, lng);
     expect(short, equals(shortCode));
   }
-  if (testType == "B" || testType == "R") {
-    String expanded = olc.recoverNearest(shortCode, lat, lng);
+  if (testType == 'B' || testType == 'R') {
+    var expanded = olc.recoverNearest(shortCode, lat, lng);
     expect(expanded, equals(code));
   }
 }
 
-main() {
+void main() {
   test('Check short codes', () {
     csvLinesFromFile('shortCodeTests.csv').forEach(checkShortCode);
   });

--- a/dart/test/utils.dart
+++ b/dart/test/utils.dart
@@ -4,14 +4,14 @@ import 'package:path/path.dart' as path;
 List<String> getCsvLines(String fileName) {
   return File(fileName)
       .readAsLinesSync()
-      .where((x) => !x.isEmpty && !x.startsWith('#'))
+      .where((x) => x.isNotEmpty && !x.startsWith('#'))
       .map((x) => x.trim())
       .toList();
 }
 
 // Requires test csv files in a test_data directory under open location code project root.
 String testDataPath() {
-  Directory projectRoot = Directory.current.parent;
+  var projectRoot = Directory.current.parent;
 
   return path.absolute(projectRoot.path, 'test_data');
 }

--- a/dart/test/validity_test.dart
+++ b/dart/test/validity_test.dart
@@ -20,17 +20,17 @@ import 'utils.dart';
 
 // code,isValid,isShort,isFull
 void checkValidity(String csvLine) {
-  List<String> elements = csvLine.split(",");
-  String code = elements[0];
-  bool isValid = elements[1] == 'true';
-  bool isShort = elements[2] == 'true';
-  bool isFull = elements[3] == 'true';
+  var elements = csvLine.split(',');
+  var code = elements[0];
+  var isValid = elements[1] == 'true';
+  var isShort = elements[2] == 'true';
+  var isFull = elements[3] == 'true';
   expect(olc.isValid(code), equals(isValid));
   expect(olc.isShort(code), equals(isShort));
   expect(olc.isFull(code), equals(isFull));
 }
 
-main() {
+void main() {
   test('Check Validity', () {
     csvLinesFromFile('validityTests.csv').forEach(checkValidity);
   });


### PR DESCRIPTION
Following the style suggestion in [effective dart](https://dart.dev/guides/language/effective-dart/design#avoid-type-annotating-initialized-local-variables)

 #omit_local_variable_types
