### PR TITLE
Upgrade rust library dependencies and bump version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "open-location-code"
 description = "Library for translating between GPS coordinates (WGS84) and Open Location Code"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["James Fysh <james.fysh@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/google/open-location-code"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["geography", "geospatial", "gis", "gps", "olc"]
 exclude = ["rust.iml"]
 
 [dependencies]
-geo = "^0.4.3"
+geo = "0.16.0"
 
 [dev-dependencies]
-rand = "^0.6.5"
+rand = "0.8.0"

--- a/rust/src/interface.rs
+++ b/rust/src/interface.rs
@@ -307,7 +307,7 @@ pub fn recover_nearest(code: &str, ref_pt: Point<f64>) -> Result<String, String>
     }
 
     let prefix_len = SEPARATOR_POSITION - code.find(SEPARATOR).unwrap();
-    let mut code = prefix_by_reference(ref_pt, prefix_len) + code;
+    let code = prefix_by_reference(ref_pt, prefix_len) + code;
 
     let code_area = decode(code.as_str()).unwrap();
 

--- a/rust/tests/all_test.rs
+++ b/rust/tests/all_test.rs
@@ -136,9 +136,9 @@ fn benchmark_test() {
     let loops = 100000;
     let mut bd: Vec<BenchmarkData> = Vec::new();
     for _i in 0..loops {
-        let lat = rng.gen_range(-90.0, 90.0);
-        let lng = rng.gen_range(-180.0, 180.0);
-        let mut len = rng.gen_range(2, 15);
+        let lat = rng.gen_range(-90.0..90.0);
+        let lng = rng.gen_range(-180.0..180.0);
+        let mut len = rng.gen_range(2..15);
         // Make sure the length is even if it's less than 10.
         if len < 10 && len % 2 == 1 {
             len += 1;


### PR DESCRIPTION
The Rust library depends on rather outdated versions of `geo` and `rand` so this PR upgrades to the most recent ones. To be usable with the wider ecosystem, a new version will have to be pushed to crates.io so I've bumped the library version accordingly. 