### PR TITLE
Remove refs to "prefix" and optional separator

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -4,13 +4,10 @@ The following public methods should be provided by any Open Location Code
 implementation, subject to minor changes caused by language conventions.
 
 Note that any method that returns an Open Location Code should return
-upper case characters, with the prefix, and full codes should include
-a separator if they have five or more characters.
+upper case characters.
 
 Methods that accept Open Location Codes as parameters should be case
-insensitive, prefixes optional, and for full codes the separator character
-is optional (although if present, it is permissable to throw an error if
-there are more than one or if it is in the wrong position).
+insensitive.
 
 isValid:
   The isValid method takes a single parameter, a string, and returns a
@@ -42,7 +39,7 @@ isFull:
 encode:
     Encode a location into an Open Location Code. This takes a latitude and
     longitude and an optional length. If the length is not specified, a code
-    with 10 characters (excluding the prefix and separator) will be generated.
+    with 10 digits and an additional separator character will be generated.
 
 decode:
     Decodes an Open Location Code into the location coordinates. This method


### PR DESCRIPTION
This file still mentioned both a "prefix character" and an "optional separator". This must be outdated references to a previous OLC format ("+xxxx.xx") that no longer exist elsewhere in the specifications. This changes removes these references.