### PR TITLE
Update TargetRubyVersion in gemspec to be oldest official supported ruby version

### DIFF
--- a/ruby/open-location-code.gemspec
+++ b/ruby/open-location-code.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*']
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_development_dependency 'test-unit'
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,5 +1,8 @@
 # Override rubocop defaults.
 
+AllCops:
+  TargetRubyVersion: 2.5
+
 Layout/LineLength:
   Enabled: true
   Max: 80


### PR DESCRIPTION
To match the default value rubocop has set as required.

* Fixing `Gemspec/RequiredRubyVersion: required_ruby_version (2.4, declared in open-location-code.gemspec) and TargetRubyVersion (2.5, which may be specified in .rubocop.yml) should be equal.` error (from https://travis-ci.org/github/google/open-location-code/jobs/769484507)

* 2.5 is the oldest supported version: https://github.com/rubocop/rubocop/blob/51bac9d21fbe245b69d4a3d8c067915dabd7747e/config/default.yml#L141

* Also updating our `.rubocop.yml` to hardcode the TargetRubyVersion to be 2.5 to avoid this error in the future (https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version).