### PR TITLE
Resolve conflict regarding OLC shortening

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -49,9 +49,9 @@ decode:
 
 shorten:
     Passed a valid full Open Location Code and a latitude and longitude this
-    removes as many digits as possible (up to a maximum of eight) such that
-    the resulting code is the closest matching code to the passed location.
-    A safety factor may be included.
+    removes as many digits as possible and allowed by the Open Location Code
+    specification, such that the resulting code is the closest matching code
+    to the passed location. A safety factor may be included.
     
     If the code cannot be shortened, the original full code should be
     returned.


### PR DESCRIPTION
As has been noted in #462, there's a discrepancy between this file and the OLC specification regarding the number of digits that can be removed while shortening. This PR resolves this conflict in a minimally invasive way by referencing the specification instead of claiming a different value.

This resolves the aforementioned #462, which can then be closed. Please check if version number needs a patch-level bump due to this change.