### PR TITLE
Fix ruby/js build issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.5'
+          ruby-version: '2.6'
       - name: test
         run: |
           gem install rubocop

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,10 @@ http_archive(
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
     sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
     strip_prefix = "zlib-1.2.11",
-    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+    urls = [
+        "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
+        "https://zlib.net/zlib-1.2.11.tar.gz",
+    ],
 )
 # com_google_protobuf depends on zlib, not net_zlib, so we need to bind.
 bind(

--- a/ruby/lib/plus_codes/open_location_code.rb
+++ b/ruby/lib/plus_codes/open_location_code.rb
@@ -198,7 +198,7 @@ module PlusCodes
       max_diff = [lat_diff, lng_diff].max
       [8, 6, 4].each do |removal_len|
         area_edge = precision_by_length(removal_len) * 0.3
-        return code[removal_len..-1] if max_diff < area_edge
+        return code[removal_len..] if max_diff < area_edge
       end
 
       code.upcase
@@ -255,7 +255,7 @@ module PlusCodes
       if code.include?(PADDING)
         return false if code.index(SEPARATOR) < SEPARATOR_POSITION
         return false if code.start_with?(PADDING)
-        return false if code[-2..-1] != PADDING + SEPARATOR
+        return false if code[-2..] != PADDING + SEPARATOR
 
         paddings = code.scan(/#{PADDING}+/)
         return false if !paddings.one? || paddings[0].length.odd?

--- a/ruby/open-location-code.gemspec
+++ b/ruby/open-location-code.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*']
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.add_development_dependency 'test-unit'
 end

--- a/ruby/open-location-code.gemspec
+++ b/ruby/open-location-code.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*']
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.6'
 
   s.add_development_dependency 'test-unit'
 end

--- a/ruby/open-location-code.gemspec
+++ b/ruby/open-location-code.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*']
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.add_development_dependency 'test-unit'
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,7 +1,7 @@
 # Override rubocop defaults.
 
 AllCops:
-  TargetRubyVersion: 2.6.5
+  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Enabled: true

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,7 +1,7 @@
 # Override rubocop defaults.
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.6.5
 
 Layout/LineLength:
   Enabled: true

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,7 +1,7 @@
 # Override rubocop defaults.
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Enabled: true


### PR DESCRIPTION
Fixing CI build issues:
1. ruby issues: (support for 2.5 dropped by rubocop: https://github.com/rubocop/rubocop/commit/1a60305ffbeb6128d29b631628167e832e21bd9f)
      1. `rubocop-ast requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.` 
      2. `Style/SlicingWithRange: Prefer ary[n..] over ary[n..-1].`
2. js-closure issue: `Download from https://zlib.net/zlib-1.2.11.tar.gz failed: class java.io.FileNotFoundException GET returned 404 Not Found`