### PR TITLE
Update API.txt to clarify the conflict with specification.md

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -49,7 +49,7 @@ decode:
 
 shorten:
     Passed a valid full Open Location Code and a latitude and longitude this
-    removes as many digits as possible (up to a maximum of eight) such that
+    removes as many digits as possible (up to a maximum of six) such that
     the resulting code is the closest matching code to the passed location.
     A safety factor may be included.
     


### PR DESCRIPTION
At most six digits can be removed to result in a valid short Plus Code.