### PR TITLE
Added null safety for Dart 3

### DIFF
--- a/dart/lib/src/open_location_code.dart
+++ b/dart/lib/src/open_location_code.dart
@@ -134,7 +134,12 @@ bool isValid(String code) {
     if (padMatch.length != 1) {
       return false;
     }
-    var matchLength = padMatch.first.group(0).length;
+    var matches = padMatch.first.group(0);
+    if (matches == null) {
+      return false;
+    }
+
+    var matchLength = matches.length;
     if (matchLength.isOdd || matchLength > separatorPosition - 2) {
       return false;
     }

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -3,6 +3,6 @@ description: Open Location Codes are short, generated codes that can be used lik
 version: 0.0.1
 homepage: http://openlocationcode.com/
 environment:
-  sdk: '<3.0.0'
+  sdk: '^2.19.6'
 dev_dependencies:
-  test: '>=0.12.0'
+  test: ^1.24.3

--- a/dart/test/encode_test.dart
+++ b/dart/test/encode_test.dart
@@ -23,7 +23,7 @@ void checkEncodeDecode(String csvLine) {
   var elements = csvLine.split(',');
   num lat = double.parse(elements[0]);
   num lng = double.parse(elements[1]);
-  num len = int.parse(elements[2]);
+  int len = int.parse(elements[2]);
   var want = elements[3];
   var got = olc.encode(lat, lng, codeLength: len);
   expect(got, equals(want));


### PR DESCRIPTION
- Added null safety for Dart 3 with a few lines.
- `dart test` is passing for both Dart 3 and Dart 2 runtimes.