### PR TITLE
Update main.yml to ignore unnecessarily generated surefire-report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: test
-        run: bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package
+        run: bazel test --test_output=all ${OLC_PATH}:all && cd ${OLC_PATH} && mvn package -Dsurefire.useFile=false -DdisableXmlReport=true
         
   # Javascript Closure library implementation. Lives in js/closure, tested with bazel.  
   test-js-closure:


### PR DESCRIPTION
From #559 (bot authored, CLA not signed):

> In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -Dsurefire.useFile=false -DdisableXmlReport=true to the mvn command.