### PR TITLE
Correct path to openlocationcode package in python tests

### DIFF
--- a/python/openlocationcode_test.py
+++ b/python/openlocationcode_test.py
@@ -5,7 +5,7 @@ from io import open
 import random
 import time
 import unittest
-from openlocationcode import openlocationcode as olc
+from python.openlocationcode import openlocationcode as olc
 
 # Location of test data files.
 _TEST_DATA = 'test_data'


### PR DESCRIPTION
Addresses part of issue #645

At some point (python 3?) this started requiring the directory name as a prefix.