### PR TITLE
Update python versions used for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
       OLC_PATH: python
     strategy:
       matrix:
-        python: [ '3.12', '3.13', '3.14' ]
+        python: [ '3.11', '3.12', '3.13' ]
     name: test-python-${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
       OLC_PATH: python
     strategy:
       matrix:
-        python: [ '2.7', '3.6', '3.7', '3.8' ]
+        python: [ '3.12', '3.13', '3.14' ]
     name: test-python-${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This changes the python versions to the current stable (3.14) and the bug fix releases (3.13, 3.12).

See issue #645.