### PR TITLE
Fix mentions of Open Location Code and plus codes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To make a suggestion [file an issue](https://github.com/google/open-location-cod
 
 If you are intending to implement, please see the [Contributing code](#contributing-code) section below for next steps.
 
-If you are adding Open Location Codes to your project, please contact the [Open Location Code Google Group](https://groups.google.com/forum/#!forum/open-location-code) so we can suggest how you can make the most of the codes.
+If you are adding Open Location Code to your project, please contact the [Open Location Code Google Group](https://groups.google.com/forum/#!forum/open-location-code) so we can suggest how you can make the most of the codes.
 
 ## Contributing code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To make a suggestion [file an issue](https://github.com/google/open-location-cod
 
 If you are intending to implement, please see the [Contributing code](#contributing-code) section below for next steps.
 
-If you are adding Open Location Code to your project, please contact the [Open Location Code Google Group](https://groups.google.com/forum/#!forum/open-location-code) so we can suggest how you can make the most of the codes.
+If you are adding the Open Location Code library to your project, please contact the [Open Location Code Google Group](https://groups.google.com/forum/#!forum/open-location-code) so we can suggest how you can make the most of the codes.
 
 ## Contributing code
 

--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -50,7 +50,7 @@ You can tell if it's in a different city without having to know the street name.
 
 ### Why is Open Location Code based on latin characters?
 
-We are aware that many of the countries where Open Location Code will be most useful use non-Latin character sets, such as Arabic, Chinese, Cyrillic, Thai, Vietnamese, etc.
+We are aware that many of the countries where Plus Codes will be most useful use non-Latin character sets, such as Arabic, Chinese, Cyrillic, Thai, Vietnamese, etc.
 We selected Latin characters as the most common second-choice character set in these locations.
 We considered defining alternative Open Location Code alphabets in each character set, but this would result in codes that would be unusable to visitors to that region, or internationally.
 

--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -4,29 +4,29 @@
 - [Open Location Code Frequently Asked Questions](#open-location-code-frequently-asked-questions)
   - [Table Of Contents](#table-of-contents)
   - [Background](#background)
-    - ["plus codes" or "Open Location Code"?](#plus-codes-or-open-location-code)
+    - ["Plus Codes" or "Open Location Code"?](#plus-codes-or-open-location-code)
     - [What are they for?](#what-are-they-for)
     - [Why not use street addresses?](#why-not-use-street-addresses)
     - [Why not use latitude and longitude?](#why-not-use-latitude-and-longitude)
     - [Why is Open Location Code based on latin characters?](#why-is-open-location-code-based-on-latin-characters)
-  - [Plus code digital addresses](#plus-code-digital-addresses)
+  - [Plus Code digital addresses](#plus-code-digital-addresses)
     - [Reference location dataset](#reference-location-dataset)
-    - [Plus code addresses in Google Maps](#plus-code-addresses-in-google-maps)
-    - [Plus code addresses of high-rise buildings](#plus-code-addresses-of-high-rise-buildings)
-    - [Plus code precision](#plus-code-precision)
+    - [Plus Code addresses in Google Maps](#plus-code-addresses-in-google-maps)
+    - [Plus Code addresses of high-rise buildings](#plus-code-addresses-of-high-rise-buildings)
+    - [Plus Code precision](#plus-code-precision)
 
 
 
 ## Background
 
-### "plus codes" or "Open Location Code"?
+### "Plus Codes" or "Open Location Code"?
 
 The software library (and this GitHub project) is called "Open Location Code", because it's a location code that is open source.
-The codes it generates are called "plus codes" because they have a plus sign in them.
+The codes it generates are called "Plus Codes" because they have a plus sign in them.
 
 ### What are they for?
 
-Plus codes provide a short reference to any location.
+Plus Codes provide a short reference to any location.
 We created them to provide a way to refer to any location, regardless of whether there are named roads, unnamed roads, or no roads at all.
 
 ### Why not use street addresses?
@@ -36,7 +36,7 @@ Also, at lot of the roads in the world don't have names, and so locations along 
 There is an estimate by the World Bank that the majority of urban roads don't have names.
 
 Street-based addressing projects are expensive and slow, and haven't made much of a dent in this problem.
-Plus codes can be assigned rapidly and because they can be used immediately can solve the addressing problem quickly and cheaply.
+Plus Codes can be assigned rapidly and because they can be used immediately can solve the addressing problem quickly and cheaply.
 
 ### Why not use latitude and longitude?
 
@@ -50,14 +50,14 @@ You can tell if it's in a different city without having to know the street name.
 
 ### Why is Open Location Code based on latin characters?
 
-We are aware that many of the countries where Open Location Codes will be most useful use non-Latin character sets, such as Arabic, Chinese, Cyrillic, Thai, Vietnamese, etc.
+We are aware that many of the countries where Open Location Code will be most useful use non-Latin character sets, such as Arabic, Chinese, Cyrillic, Thai, Vietnamese, etc.
 We selected Latin characters as the most common second-choice character set in these locations.
 We considered defining alternative Open Location Code alphabets in each character set, but this would result in codes that would be unusable to visitors to that region, or internationally.
 
-## Plus code digital addresses
+## Plus Code digital addresses
 
-Plus code digital addresses use known address information, like country, state, city, and then use the plus code to provide the final information.
-Typically converting a plus code to a plus code address removes the first four digits from the code to shorten it to just six digits.
+Plus Code digital addresses use known address information, like country, state, city, and then use the Plus Code to provide the final information.
+Typically converting a Plus Code to a Plus Code address removes the first four digits from the code to shorten it to just six digits.
 
 Any city or place name within approximately 30-50 km can be used to recover the original location.
 
@@ -69,26 +69,26 @@ Callers will need to convert place names to/from latlng using a geocoding system
 Providing a global dataset isn't within scope of this project.
 For a potential free alternative, see [Open Street Map](https://wiki.openstreetmap.org/) and derived geocoding service [Nominatim](https://nominatim.org/).
 
-### Plus code addresses in Google Maps
+### Plus Code addresses in Google Maps
 
-Google Maps displays plus code addresses on all entries.
-It does this by using the location of the business for the plus code, and then using the place name to shorten the plus code to a more convenient form.
+Google Maps displays Plus Code addresses on all entries.
+It does this by using the location of the business for the Plus Code, and then using the place name to shorten the Plus Code to a more convenient form.
 
 If the listing is managed by the business owner, it will try to use a place name from the address, otherwise it will use Google's best guess for the place name. (Google tries to pick names for cities rather than suburbs or neighbourhoods.)
 
-If you think a different place name would be better, you can use that, and as long as Google knows about that place name the plus code address should work.
+If you think a different place name would be better, you can use that, and as long as Google knows about that place name the Plus Code address should work.
 
-### Plus code addresses of high-rise buildings
+### Plus Code addresses of high-rise buildings
 
-Plus codes don't include the floor or apartment in high-rise buildings.
-If you live in a multi-storey building located at "9G8F+6W, Zürich, Switzerland", think of the plus code as like the street name and number, and put your floor or apartment number in front: "Fourth floor, 9G8F+6W, Zürich, Switzerland"
+Plus Codes don't include the floor or apartment in high-rise buildings.
+If you live in a multi-storey building located at "9G8F+6W, Zürich, Switzerland", think of the Plus Code as like the street name and number, and put your floor or apartment number in front: "Fourth floor, 9G8F+6W, Zürich, Switzerland"
 
-The reason for this is that plus codes need to be created without knowing specifically what is there.
+The reason for this is that Plus Codes need to be created without knowing specifically what is there.
 The other reason is that addresses in high-rise buildings are assigned differently in different parts of the world, and we don't need to change that.
 
-### Plus code precision
+### Plus Code precision
 
-The precision of a plus code is indicated by the number of digits after the "+" sign.
+The precision of a Plus Code is indicated by the number of digits after the "+" sign.
 
 *  Two digits after the plus sign is an area roughly 13.7 by 13.7 meters;
 *  Three digits after the plus sign is an area roughly 2.7 by 3.5 meters;
@@ -96,5 +96,4 @@ The precision of a plus code is indicated by the number of digits after the "+" 
 
 Apps can choose the level of precision they display, but should bear in mind the likely precision of GPS devices like smartphones, and the increased difficulty of remembering longer codes.
 
-One reason to use three or four digits after the plus sign might be when addressing areas that contain small dwellings, to avoid having multiple dwellings with the same plus code address.
-
+One reason to use three or four digits after the plus sign might be when addressing areas that contain small dwellings, to avoid having multiple dwellings with the same Plus Code address.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -19,8 +19,8 @@ The wiki is where you can find out information about using the software, the cod
 ### Technical
 
 * [An Evaluation of Location Encoding Systems](Reference/comparison.adoc)
-* [Supporting plus codes in GIS software](Reference/GIS_Software.md)
-* [Supporting plus codes in an app](Reference/App_Developers.md)
+* [Supporting Plus Codes in GIS software](Reference/GIS_Software.md)
+* [Supporting Plus Codes in an app](Reference/App_Developers.md)
 
 ### Tools
 

--- a/Documentation/Reference/App_Developers.md
+++ b/Documentation/Reference/App_Developers.md
@@ -1,14 +1,15 @@
-# Supporting plus codes technology in apps and sites
+# Supporting Plus Codes technology in apps and sites
 
-This page gives guidelines for how to support plus codes in a website or mapping application.
+This page gives guidelines for how to support Plus Codes in a website or mapping application.
 These guidelines should make it clear that adding support for OLC is not onerous, but actually quite easy.
 
 > Note that with the availability of the [https://plus.codes website API](plus.codes_Website_API.md), these instructions really only apply to apps that require offline support.
 If your app or site can rely on a network connection, integrating with the API will give a better solution.
 
-# Supporting plus codes for search
+# Supporting Plus Codes for search
 
-To support plus codes for searching, there are three different cases:
+To support Plus Codes for searching, there are three different cases:
+
 * global codes, such as "796RWF8Q+WF"
 * local codes, such as "WF8Q+WF"
 * local codes with a locality, such as "WF8Q+WF Praia, Cabo Verde"
@@ -51,13 +52,13 @@ Use the location returned by your geocoding service as the reference location in
 
 ## Displaying the result
 
-If the user specified a plus code in their query, the result should match.
-That is, it is easier to understand if they enter a plus code to get a plus code displayed as the result.
-Searching for a plus code and displaying the result back to the user as "14°55'02.3"N 23°30'40.7"W" is confusing, unhelpful and should be avoided.
+If the user specified a Plus Code in their query, the result should match.
+That is, it is easier to understand if they enter a Plus Code to get a Plus Code displayed as the result.
+Searching for a Plus Code and displaying the result back to the user as "14°55'02.3"N 23°30'40.7"W" is confusing, unhelpful and should be avoided.
 
-# Computing plus codes for places
+# Computing Plus Codes for places
 
-Superficially computing plus codes for places is trivial.
+Superficially computing Plus Codes for places is trivial.
 All that is needed is to call the `encode()` method on the coordinates, and then to display the code.
 
 The problem is that this only displays the global code, not the more convenient and easy to remember local code.
@@ -77,17 +78,17 @@ Some geocoding backends are more suitable than others, so you might need to perf
 ## Ensuring the locality is near enough
 
 After reverse geocoding the location and extracting the locality name, you should make a call to a geocoding service to get the location of the locality.
-This is likely to be its center, not the position of the plus code, and could be some distance away.
+This is likely to be its center, not the position of the Plus Code, and could be some distance away.
 
 You want it to be as close as possible, because other geocoding services are likely to position it slightly differently.
-If it is very close to half a degree away, another geocoding service could result in the plus code being decoded to a different location.
+If it is very close to half a degree away, another geocoding service could result in the Plus Code being decoded to a different location.
 
 Typically you should aim for a locality within a quarter of a degree - this is approximately 25km away (at the equator) so still quite a large range.
 
 If the locality is near enough, you should display the local code and locality together.
 The `shorten()` method in the OLC library may remove 2, 4, 6 or even 8 characters, depending on how close the reference location is.
-Although all of these are valid, we recommend only removing the first 4 characters, so that plus codes have a consistent appearance.
+Although all of these are valid, we recommend only removing the first 4 characters, so that Plus Codes have a consistent appearance.
 
 # Summary
 
-Supporting plus codes in search use cases should not be a complex exercise.
+Supporting Plus Codes in search use cases should not be a complex exercise.

--- a/Documentation/Reference/Field_Collection_Data_Practices.md
+++ b/Documentation/Reference/Field_Collection_Data_Practices.md
@@ -3,20 +3,20 @@
 
 ## Summary
 
-Collecting locations of equipment, buildings, homes etc from the field, and obtaining the plus codes, is a common problem.
+Collecting locations of equipment, buildings, homes etc from the field, and obtaining the Plus Codes, is a common problem.
 
 [Open Data Kit](https://opendatakit.org) is a suite of free and open source software to support collecting, managing and using data. [Open Data Kit Collect](https://play.google.com/store/apps/details?id=org.odk.collect.android) (ODK Collect) is a free, open source app available in the Google Play Store for customizable data collection in an offline environment.
 
-This document explains how to get started with ODK to collect location data and convert it to plus codes.
+This document explains how to get started with ODK to collect location data and convert it to Plus Codes.
 
-**Note:** This process will collect latitude and longitude and convert them to global plus codes, e.g. 8FVC9G8F+6W.
-Converting these to plus code addresses (9G8F+6W Zurich, Switzerland) is out of scope of this data collection. (One way it could be done is using the [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro).)
+**Note:** This process will collect latitude and longitude and convert them to global Plus Codes, e.g. 8FVC9G8F+6W.
+Converting these to Plus Code addresses (9G8F+6W Zurich, Switzerland) is out of scope of this data collection. (One way it could be done is using the [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro).)
 
 ## Overview
 
 First we will define a [form](https://docs.opendatakit.org/form-design-intro/) that specifies what data we want, and then use [ODK Collect](https://docs.opendatakit.org/collect-intro/), an Android app, to collect filled in forms.
 
-ODK Collect saves location information as latitude and longitude, so the final step will be to convert those to plus codes using the [plus code add-on for Google Sheets](https://gsuite.google.com/marketplace).
+ODK Collect saves location information as latitude and longitude, so the final step will be to convert those to Plus Codes using the [Plus Code add-on for Google Sheets](https://gsuite.google.com/marketplace).
 
 ## Requirements
 
@@ -25,10 +25,10 @@ ODK Collect saves location information as latitude and longitude, so the final s
 
 ## Alternatives
 
-Other options for collecting this data might be to use Google Maps - manually long pressing on the map displays an address card, and expanding that shows the plus code.
+Other options for collecting this data might be to use Google Maps - manually long pressing on the map displays an address card, and expanding that shows the Plus Code.
 
 Alternatively, you could write an HTML5 web app or develop another mobile app.
-These could do the conversion from GPS coordinates to plus codes directly.
+These could do the conversion from GPS coordinates to Plus Codes directly.
 However, we think that using Open Data Kit provides the fastest route to general functionality.
 
 ## Using Open Data Kit
@@ -91,8 +91,8 @@ ODK uploads locations to the sheet using three fields:
 * altitude (set to zero for manual locations)
 * accuracy (set to zero for manual locations)
 
-To convert these to plus codes, install the Google Sheets plus code add-on from the [G Suite Marketplace](https://gsuite.google.com/marketplace).
-You can convert a column of locations into their corresponding plus codes using the formula:
+To convert these to Plus Codes, install the Google Sheets Plus Code add-on from the [G Suite Marketplace](https://gsuite.google.com/marketplace).
+You can convert a column of locations into their corresponding Plus Codes using the formula:
 ```
 =PLUSCODE(B:B)
 ```

--- a/Documentation/Reference/GIS_Software.md
+++ b/Documentation/Reference/GIS_Software.md
@@ -1,15 +1,15 @@
-# Plus codes in GIS software
+# Plus Codes in GIS software
 
-This page provides information about using plus codes in GIS software.
+This page provides information about using Plus Codes in GIS software.
 
 ## Tile Service
 
-If you want to visualise the plus codes grid, you can use the [grid service](https://grid.plus.codes) to fetch the grid tiles.
+If you want to visualise the Plus Codes grid, you can use the [grid service](https://grid.plus.codes) to fetch the grid tiles.
 
 This is a shared service, and it may rate limit you.
 If you need to use the grid heavily, you can start your own [tile_server](https://github.com/google/open-location-code/blob/main/tile_server).
 
-The tile service provides GeoJSON objects, one per plus codes square, or PNG images that can be added as an overlay.
+The tile service provides GeoJSON objects, one per Plus Codes square, or PNG images that can be added as an overlay.
 
 ## Software
 
@@ -40,15 +40,15 @@ In QGIS, you can generate a grid by clicking in the top Menu: Vector > Research 
 * And that should generate the grid for you.
   You can save that layer as a shapefile in any format.
 
-Note that this will not put any information about the plus codes in your grid's metadata.
+Note that this will not put any information about the Plus Codes in your grid's metadata.
 They're just lines/boxes.
 
-But if you make polygons, then I can think of a roundabout way of adding plus code values to those polygons (I have not done this myself yet):
+But if you make polygons, then I can think of a roundabout way of adding Plus Code values to those polygons (I have not done this myself yet):
 
 * Generate a centroid layer (Vector > Geometry Tools > Polygon Centroid) from the grid-polygons layer.
   This will place points inside each grid box. (in a new points layer.)
 * Install "Lat Lon Tools" plugin.
-* That plugin can generate plus codes from points.
+* That plugin can generate Plus Codes from points.
   So run it on the centroid layer you made.
 * (And this I can't quite figure out yet) Figure out a way to move the meta field from the centroid layer to the grid polygons layer.
 

--- a/Documentation/Reference/Plus_Code_Users.md
+++ b/Documentation/Reference/Plus_Code_Users.md
@@ -5,7 +5,7 @@ This page lists the sites, apps and organisations that support Plus Codes / Open
 # Organisations
 
 * [Correios de Cabo Verde](correios.cv) (August 2016).
-  Support plus codes for postal delivery.
+  Support Plus Codes for postal delivery.
 
 # Apps and sites
 
@@ -14,7 +14,7 @@ This page lists the sites, apps and organisations that support Plus Codes / Open
   * Display of global codes in [Android](https://play.google.com/store/apps/details?id=com.google.android.apps.maps) and [iOS](https://itunes.apple.com/app/id585027354) maps (September 2016).
   * [Assistant integration](https://assistant.google.com/services/a/uid/000000706b4e2cf1?hl=en) (early 2018)
 * [mapy.cz](mapy.cz) (mid 2016) Search support for global codes.
-* www.waze.com (early 2018?) Search support for plus code addresses (global and local)
+* www.waze.com (early 2018?) Search support for Plus Code addresses (global and local)
 * www.locusmap.eu (early 2018) Supports using global codes to set the map location
 * [OSMAnd](https://osmand.net/) OpenStreetMap based offline mobile maps and navigation - Supports displaying OLC as the "coordinates" of any point on earth.
 * [QGIS](https://qgis.org/) via [Lat Lon Tools](https://plugins.qgis.org/plugins/latlontools/) plug in - good support, points to olc, olc to points

--- a/Documentation/Reference/Using_Spreadsheets.md
+++ b/Documentation/Reference/Using_Spreadsheets.md
@@ -1,12 +1,12 @@
 # Using Plus Codes in Spreadsheets
 
-Being able to work with plus codes in spreadsheets is, for most people, probably the easiest method to work with them in bulk.
+Being able to work with Plus Codes in spreadsheets is, for most people, probably the easiest method to work with them in bulk.
 
 This page explains how you can access the Open Location Code functions from Excel, LibreOffice or Google Spreadsheets.
 
 ## Google Sheets
 
-There is an [add-on for Google Sheets](https://gsuite.google.com/marketplace/app/plus_codes/604254879289) that allows you to create plus codes from latitude and longitude coordinates, and to decode them as well.
+There is an [add-on for Google Sheets](https://gsuite.google.com/marketplace/app/plus_codes/604254879289) that allows you to create Plus Codes from latitude and longitude coordinates, and to decode them as well.
 
 The [Google Maps YouTube channel](https://www.youtube.com/@googlemaps) has some [videos showing how to install and use the add-on](https://www.youtube.com/playlist?list=PLcRbp4LqBpwE5ofG2MN08D_4DJAk9gZBI).
 

--- a/Documentation/Reference/comparison.adoc
+++ b/Documentation/Reference/comparison.adoc
@@ -111,8 +111,8 @@ cell marked g) is next to the cell 9X, but further from g7 (which is next to
 G2). Using real Geohash-36 codes, "bdg345476Q" is next to "bdbtTVTXWB" but
 several kilometers from "bdg3Hhg4Xd".
 
-Geohash-36 codes may be one character shorter than full Open Location Codes
-for similar accuracies.
+Geohash-36 codes may be one character shorter than full Plus Code for similar
+accuracies.
 
 The Geohash-36 definition includes an optional altitude specification, and
 an optional checksum, neither of which are provided by Open Location Code.
@@ -120,9 +120,9 @@ an optional checksum, neither of which are provided by Open Location Code.
 == MapCode
 
 MapCodes can be defined globally or within a containing territory
-<<mapcode>>. The global codes are a similar length to Open Location Codes,
-but codes defined within a territory are shorter than full Open Location
-Codes, and a similar length to short Open Location Codes.
+<<mapcode>>. The global codes are a similar length to Plus Codes, but codes
+defined within a territory are shorter than full Plus Codes, and a similar
+length to short Plus Codes.
 
 To decode the identifiers, a data file needs to be maintained and
 distributed. The identifiers are mostly ISO-3166 codes for the territory
@@ -149,9 +149,9 @@ character set.
 == Open Post Code
 
 Open Post Codes <<openpostcode-site>> can be defined globally or within a containing country
-<<openpostcode>>. The global codes are a similar length to Open Location
-Codes, but codes defined within a country are shorter than full Open
-Location Codes, and a similar length to short Open Location Codes.
+<<openpostcode>>. The global codes are a similar length to Plus Codes, but
+codes defined within a country are shorter than full Plus Code, and a similar
+length to short Plus Codes.
 
 Four countries are defined: Ireland, Hong Kong, Yemen and India.
 
@@ -208,7 +208,7 @@ Natural Area Codes have a discontinuity at longitude 180 and at the poles.
 == Maidenhead Locator System (MLS)
 
 Maidenhead Locator System codes explicitly represent areas, and can be
-truncated in a similar way to Open Location Codes. The accuracy and length of the codes is similar. MLS cannot generate words, but it can generate sequences that may appear to be words (e.g. when reading "1" as "l") <<mls>>.
+truncated in a similar way to Plus Codes. The accuracy and length of the codes is similar. MLS cannot generate words, but it can generate sequences that may appear to be words (e.g. when reading "1" as "l") <<mls>>.
 
 Maidenhead Locator System codes are based on an interleaving of latitude and
 longitude, and so are truncatable, and nearby locations have similar codes.
@@ -249,9 +249,9 @@ information such as contact details, photos etc in addition to the location.
 
 We felt that the attributes of the above systems didn't sufficiently meet
 our requirements. As a result, we defined a new coding system and termed it
-Open Location Code; codes created using this system are referred to as 'plus codes' (see the link:../Specification/Naming_Guidelines.md[Naming Guidelines]).
+Open Location Code; codes created using this system are referred to as 'Plus Codes' (see the link:../Specification/Naming_Guidelines.md[Naming Guidelines]).
 
-Plus codes are 10 to 11 characters long. They can also be used in a
+Plus Codes are 10 to 11 characters long. They can also be used in a
 short form of four to seven characters, similar to telephone numbers and
 postcodes, within approximately 50km of the original location. Within
 approximately 2.5km of the original location they can be shortened further,
@@ -260,12 +260,12 @@ to just four to five characters.
 To aid recognition and memorisation, we include a separator to break the code
 into two parts, and to distinguish codes from postal codes.
 
-In their short form, plus codes have from four to seven characters.
+In their short form, Plus Codes have from four to seven characters.
 These can be used on their own within 50km of the place, or globally by
-providing a city or locality within that distance. Full plus code
+providing a city or locality within that distance. Full Plus Code
 require no other information to locate them.
 
-There is only one plus code for a given location and area size.
+There is only one Plus Code for a given location and area size.
 Different codes can be generated with different areas, but they will share
 the leading characters.
 
@@ -279,14 +279,14 @@ billion possibilities, using a word list of 10,000 words from 30 languages.
 All possible sets were scored on whether they could spell the test words,
 and the most promising sets evaluated by hand.
 
-The character set used to form plus codes is not contiguous. This
+The character set used to form Plus Codes is not contiguous. This
 is a result of removing easily confused characters, vowels and some other
 characters. This does make manually comparing codes difficult, as one has to
 remember whether there are characters between 9 and C in order to tell if
 8FV9 is next to 8FVC. However, we think that this is justified by the
 improved usability.
 
-Nearby places have similar plus codes. There are three
+Nearby places have similar Plus Codes. There are three
 discontinuities, at longitude 180 and at the north and south poles, where
 nearby locations can have very different codes, but due to the low
 populations in these areas we feel this is an acceptable limitation.
@@ -297,19 +297,19 @@ latitudes are clipped to be greater than or equal to -90 and less than 90
 degrees, making representing the exact location of the North Pole impossible
 although it can be very closely approximated.
 
-Plus codes represent areas, and the size of the area depends on the
+Plus Codes represent areas, and the size of the area depends on the
 code length. The longer the code, the smaller and more accurate the area.
 
-Truncating a plus code increases the area and contains the
+Truncating a Plus Code increases the area and contains the
 original location.
 
 The codes are based on a simple encoding of latitude and longitude. The code
 for a place can be looked up by anyone and does not require any setup or
 configuration.
 
-Plus codes can be encoded and decoded offline.
+Plus Codes can be encoded and decoded offline.
 
-Plus codes do not depend on any infrastructure, and so are not
+Plus Codes do not depend on any infrastructure, and so are not
 dependent on any organisation or company for their continued existence or
 usage.
 

--- a/Documentation/Reference/plus.codes_Website_API.md
+++ b/Documentation/Reference/plus.codes_Website_API.md
@@ -215,7 +215,7 @@ This is because for large features, the returned code will be the **largest** co
 ## API Keys
 
 ### Obtaining A Google API Key
-To search for addresses, return addresses, and return short codes and localities, the Open Location Code uses the [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro).
+To search for addresses, return addresses, and return short codes and localities, the Plus Codes API uses the [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro).
 If you want to be able to:
 *  search by address,
 *  search by short codes with localities,

--- a/Documentation/Reference/plus.codes_Website_API.md
+++ b/Documentation/Reference/plus.codes_Website_API.md
@@ -1,4 +1,4 @@
-# https://plus.codes API Developer's Guide
+# <https://plus.codes> API Developer's Guide
 
 ### Table of Contents
 - [https://plus.codes API Developer's Guide](#httpspluscodes-api-developers-guide)
@@ -37,13 +37,13 @@ A side effect of this update is that the API should be slightly faster, and if A
 
 The API provides the following functions:
 
-*  Conversion of a latitude and longitude to a plus code (including the bounding box and the center);
-*  Conversion of a plus code to the bounding box and center.
+*  Conversion of a latitude and longitude to a Plus Code (including the bounding box and the center);
+*  Conversion of a Plus Code to the bounding box and center.
 
 Additionally, it can use the [Google Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro) to:
 
-*  Include short codes and localities in the returned plus code (such as "WF8Q+WF Praia, Cape Verde" for "796RWF8Q+WF");
-*  Handle converting from a street address or business name to the plus code;
+*  Include short codes and localities in the returned Plus Code (such as "WF8Q+WF Praia, Cape Verde" for "796RWF8Q+WF");
+*  Handle converting from a street address or business name to the Plus Code;
 *  Handle converting a short code and locality to the global code and coordinates.
 
 The results are provided in JSON format.
@@ -51,7 +51,7 @@ The API is loosely modeled on the [Google Geocoding API](https://developers.goog
 
 ## API Request Format
 
-A Plus codes API request takes the following form:
+A Plus Codes API request takes the following form:
 
 `https://plus.codes/api?parameters`
 
@@ -157,7 +157,7 @@ The JSON response contains two root elements:
 
 *  `"status"` contains metadata on the request.
    Other status values are documented [here](https://developers.google.com/maps/documentation/geocoding/intro#StatusCodes).
-*  `"plus_code"` contains the plus code information for the location specified in `address`.
+*  `"plus_code"` contains the Plus Code information for the location specified in `address`.
 
 > There may be an additional `error_message` field within the response object.
 > This may contain additional background information for the status code.
@@ -215,7 +215,7 @@ This is because for large features, the returned code will be the **largest** co
 ## API Keys
 
 ### Obtaining A Google API Key
-To search for addresses, return addresses, and return short codes and localities, the Plus Codes API uses the [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro).
+To search for addresses, return addresses, and return short codes and localities, the Open Location Code uses the [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro).
 If you want to be able to:
 *  search by address,
 *  search by short codes with localities,
@@ -236,12 +236,12 @@ Google API keys have a free daily quota allowance.
 If other people obtain your key, they can make requests to any API that is enabled for that key, consuming your free quota, and if you have billing enabled, can incur charges.
 
 The normal way of securing API keys is setting restrictions on the host that can use it to call Google APIs.
-These methods won't work here, because the calls to the Google API are being done from the plus codes server.
+These methods won't work here, because the calls to the Google API are being done from the Plus Codes server.
 
-Instead, you can encrypt your Google API key, and use the encrypted value in the requests to the plus codes API.
-The plus codes server will decrypt the key and use the decrypted value to make the calls to Google.
+Instead, you can encrypt your Google API key, and use the encrypted value in the requests to the Plus Codes API.
+The Plus Codes server will decrypt the key and use the decrypted value to make the calls to Google.
 
-If anyone obtains your encrypted API key, they cannot use it to make direct requests to any Google API. (They can still use it to make requests to the plus codes API, see the next section for a solution.)
+If anyone obtains your encrypted API key, they cannot use it to make direct requests to any Google API. (They can still use it to make requests to the Plus Codes API, see the next section for a solution.)
 
 For example, to protect the Google API key `my_google_api_key`, encrypt it like this:
 
@@ -249,7 +249,7 @@ For example, to protect the Google API key `my_google_api_key`, encrypt it like 
 https://plus.codes/api?encryptkey=my_google_api_key
 ```
 
-The plus codes API will respond with:
+The Plus Codes API will respond with:
 
 ```javascript
 {
@@ -262,7 +262,7 @@ The plus codes API will respond with:
 ### Securing Your API Key With An HTTP Referrer
 
 For extra security, you can encrypt a hostname with the key.
-When the plus codes server decrypts the key, it checks that the HTTP referrer matches the encrypted hostname.
+When the Plus Codes server decrypts the key, it checks that the HTTP referrer matches the encrypted hostname.
 This prevents the encrypted key from being used from another host.
 
 For example, to protect the Google API key `my_google_api_key`, and require the HTTP referrer host to be `openlocationcode.com`, encrypt it like this:
@@ -271,7 +271,7 @@ For example, to protect the Google API key `my_google_api_key`, and require the 
 https://plus.codes/api?referer=openlocationcode.com&encryptkey=my_google_api_key
 ```
 
-The plus codes API will respond with:
+The Plus Codes API will respond with:
 
 ```javascript
 {

--- a/Documentation/Specification/olc_definition.adoc
+++ b/Documentation/Specification/olc_definition.adoc
@@ -170,10 +170,10 @@ many buildings
 * Using a number base of 20 makes some calculations easier
 * We could identify a 20 character subset from 0-9A-Z that doesn't spell words.
 
-The characters that are used in Open Location Codes were chosen by computing
+The characters that are used in Open Location Code were chosen by computing
 all possible 20 character combinations from 0-9A-Z and scoring them on how
 well they spell 10,000 words from over 30 languages. This was to avoid, as
-far as possible, Open Location Codes being generated that included
+far as possible, Plus Codes being generated that included
 recognisable words. The selected 20 character set is made up of
 "23456789CFGHJMPQRVWX".
 
@@ -181,7 +181,7 @@ Note on terminology: The characters from 0-9A-Z that make up the significant
 part of an Open Location Code are referred to as "digits". Additional symbols
 used for formatting are referred to as "characters".
 
-Open Location Codes are encodings of WGS84 latitude and longitude
+Open Location Code uses encodings of WGS84 latitude and longitude
 coordinates in degrees. Decoding a code returns an area, not a point. The
 area of a code depends on the length (longer codes are more precise with
 smaller areas). A two-digit code has height and width <<height_width>> of 20
@@ -198,7 +198,7 @@ direction from one code to another to be determined visually, and for codes
 to be truncated, resulting in a larger area.
 
 [[fig_olc_area]]
-.Comparing areas of four and six digit Open Location Codes
+.Comparing areas of four and six digit Plus Codes
 image::../images/code_areas.png[width=400,height=350,align="center"]
 
 The large rectangle in <<fig_olc_area>> is the Open Location Code 8FVC (1
@@ -241,7 +241,7 @@ not be reliably compared visually.
 10 and 11 digit codes provide the necessary resolution to represent
 building locations. Other lengths are also valid.
 
-== Shortening Open Location Codes
+== Shortening Plus Codes
 
 We are accustomed to providing different levels of detail in a street
 address depending on who we give it to. People far away usually require the
@@ -283,7 +283,7 @@ digits to be recovered for this code.
 
 But this means that we have a problem if we want to represent the 1x1 degree
 area 6GCR. The solution here is to use zero, as a padding symbol, giving us
-6GCR0000+. Zeros in Open Location Codes must not be followed by any other
+6GCR0000+. Zeros in Plus Codes must not be followed by any other
 digits.
 
 == Imperfections
@@ -310,7 +310,7 @@ Similarly, locations at the poles, although physically close, can also have
 significantly different encodings. The fact that there are no significant
 population centers affected means that this is an imperfection we are
 willing to accept
-* Open Location Codes cannot exactly represent coordinates at latitude 90.
+* Plus Codes cannot exactly represent coordinates at latitude 90.
 The codes for latitude 90 would normally have an area whose lower latitude
 is at 90 degrees and an upper latitude of 90 + the height of the code area,
 but this would result in meaningless coordinates. Instead, when encoding

--- a/Documentation/Specification/olc_definition.adoc
+++ b/Documentation/Specification/olc_definition.adoc
@@ -170,7 +170,7 @@ many buildings
 * Using a number base of 20 makes some calculations easier
 * We could identify a 20 character subset from 0-9A-Z that doesn't spell words.
 
-The characters that are used in Open Location Code were chosen by computing
+The characters that are used by Open Location Code were chosen by computing
 all possible 20 character combinations from 0-9A-Z and scoring them on how
 well they spell 10,000 words from over 30 languages. This was to avoid, as
 far as possible, Plus Codes being generated that included

--- a/Documentation/Specification/specification.md
+++ b/Documentation/Specification/specification.md
@@ -8,7 +8,7 @@ The latitude and longitude should be WGS84 values. If other datums are used it m
 
 ## Character Set
 
-The following defines the valid characters in an Open Location Code. Sequences that contain other characters are by definition not valid Open Location Codes.
+The following defines the valid characters in a Plus Code. Sequences that contain other characters are by definition not valid Open Location Code.
 
 ### Digits
 
@@ -158,7 +158,7 @@ The following public methods should be provided by any Open Location Code implem
 
 Note that any method that returns an Open Location Code should return upper case characters.
 
-Methods that accept Open Location Codes as parameters should be case insensitive.
+Methods that accept Plus Codes as parameters should be case insensitive.
 
 Capitalisation should follow the language convention, for example the method `isValid` in golang would be `IsValid`.
 

--- a/FAQ.txt
+++ b/FAQ.txt
@@ -12,7 +12,7 @@ codes should work offline, should not include words and should not require
 setting up. It should be possible to tell if two codes are close to each
 other by looking at them.
 
-Q: Where do we expect Open Location Codes to be useful?
+Q: Where do we expect Open Location Code to be useful?
 A: More than half the world's urban dwellers live on streets that don't have
 formal names. We expect these codes will be mostly used by people in areas
 lacking street addresses, but could also be used in areas that are mapped
@@ -28,7 +28,7 @@ approximately $5USD per addressed building. The advantage of Open Location
 Codes is that they are available now to anyone with access to a computer or
 smartphone.
 
-Q: Are there uses for Open Location Codes in well-mapped countries?
+Q: Are there uses for Open Location Code in well-mapped countries?
 A: Yes, for example Switzerland has villages where multiple streets have the
 same name. The UK has some homes that are identified by names, rather than
 by street numbers. Venice and Japan both have block-based addresses, rather
@@ -81,7 +81,7 @@ often suffice. This data might already exist for a specific application, or
 can potentially be extracted from open GIS or map data available online.
 The community mailing list can be used to ask for help with such data.
 
-Q: Why don't Open Location Codes include altitude?
+Q: Why doesn't Open Location Code include altitude?
 A: We didn't want to append it as a suffix or bury it in the code because we
 want to be able to truncate the codes reliably. We also didn't want to
 unnecessarily extend the length of codes for what we expect to be a minority
@@ -91,7 +91,7 @@ different ways of numbering building floors depending on local custom.
 In summary, we couldn't think of a way that was better than specifying the
 code and allowing people to just say "3rd floor".
 
-Q: Why do Open Location Codes use two algorithms?
+Q: Why does Open Location Code use two algorithms?
 A: The first algorithm provides codes that can be visually compared and
 sorted. This is used until the code is 10 characters long, with a resolution
 of 1/8000th of a degree, approximately 14 meters. This will often be
@@ -108,7 +108,7 @@ If we had based the entire code on the second algorithm, we would have codes
 that would not be reliably visually comparable or sortable by proximity.
 
 Q: Why is Open Location Code based on latin characters?
-A: We are aware that many of the countries where Open Location Codes will be
+A: We are aware that many of the countries where Open Location Code will be
 most useful use non-Latin character sets, such as Arabic, Chinese, Cyrillic,
 Thai, Vietnamese, etc. We selected Latin characters as the most common
 second-choice character set in these locations.
@@ -127,7 +127,7 @@ Hyderabad!") because users will realise that a code cannot possibly be
 correct. It's analogous to someone using the wrong suburb name today - it
 happens, people are able to deal with it.
 
-Q: Why do Open Location Codes look like something fell on my keyboard?
+Q: Why do Plus Codes look like something fell on my keyboard?
 A: We wanted something that wasn't linked to a single culture, so word-based
 codes were out. That meant that the codes would be essentially a number, but
 we used letters as well as digits to raise the number base and shorten the
@@ -138,14 +138,14 @@ noncontiguous, although it is difficult to see how we could change that
 without violating any of the aims.
 
 Q: What coordinate system does Open Location Code use?
-A: Open Location Codes should be based on WGS84, since this is the datum
+A: Open Location Code should be based on WGS84, since this is the datum
 used by GPS and is how coordinates on smartphone devices are made available.
 There is nothing to prevent coordinates using other datums being used, but
 when decoded by someone who expects them to be WGS84, it may result in a
 different location.
 
 Q: Why do Open Location Code areas distort at high latitudes?
-A: Open Location Codes are a function of latitude and longitude. As
+A: Plus Codes are a function of latitude and longitude. As
 longitude lines converge on the north and south poles the areas become
 narrower and narrower. At the equator codes are square, but at about 60
 degrees latitude, the codes are only half as wide.
@@ -156,12 +156,12 @@ different, even though they may be very close together. Apart from some
 islands in the Fiji group, there are almost no affected inhabited areas, and
 we feel this is acceptable. The other discontinuities are at the poles, but
 as these do not have large permanent populations we don't expect significant
-use of Open Location Codes here.
+use of Open Location Code here.
 
 Q: What about continental drift?
 A: Most tectonic plates are moving at rates of 1-5cm per year. With the 10
-character Open Location Codes representing 14x14 meter boxes, codes should
-be valid for many years. Even the more accurate 11 character codes should
-not require updating for 30-50 years. But even if they do, the worst result
-is that someone using a code will find themselves at the home or building
+character Plus Code representing 14x14 meter boxes, codes should be valid for
+many years. Even the more accurate 11 character codes should not require
+updating for 30-50 years. But even if they do, the worst result is that
+someone using a code will find themselves at the home or building
 next door.

--- a/FAQ.txt
+++ b/FAQ.txt
@@ -108,7 +108,7 @@ If we had based the entire code on the second algorithm, we would have codes
 that would not be reliably visually comparable or sortable by proximity.
 
 Q: Why is Open Location Code based on latin characters?
-A: We are aware that many of the countries where Open Location Code will be
+A: We are aware that many of the countries where Plus Codes will be
 most useful use non-Latin character sets, such as Arabic, Chinese, Cyrillic,
 Thai, Vietnamese, etc. We selected Latin characters as the most common
 second-choice character set in these locations.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Open Location Code
 [![CDNJS](https://img.shields.io/cdnjs/v/openlocationcode.svg)](https://cdnjs.com/libraries/openlocationcode)
 
 Open Location Code is a technology that gives a way of encoding location into a form that is
-easier to use than latitude and longitude. The codes generated are called plus codes, as their
+easier to use than latitude and longitude. The codes generated are called Plus Codes, as their
 distinguishing attribute is that they include a "+" character.
 
 The technology is designed to produce codes that can be used as a replacement for street addresses, especially
 in places where buildings aren't numbered or streets aren't named.
 
-Plus codes represent an area, not a point. As digits are added
+Plus Codes represent an area, not a point. As digits are added
 to a code, the area shrinks, so a long code is more precise than a short
 code.
 

--- a/android_demo/README.md
+++ b/android_demo/README.md
@@ -2,7 +2,8 @@ Android Open Location Code Demonstrator
 =======================================
 
 This is the source code for an Android app that uses
-[Open Location Codes](http://openlocationcode.com) and displays them on a map.
+[Open Location Code](https://maps.google.com/pluscodes/) and displays them on a
+map.
 
 It displays the current location, computes the code for that location, and uses
 a bundled set of place names to shorten the code to a more convenient form.

--- a/android_demo/android/src/main/res/values/strings.xml
+++ b/android_demo/android/src/main/res/values/strings.xml
@@ -38,7 +38,8 @@
     <string name="search_empty">Enter a code to search</string>
 
     <string name="welcome_page_title">Discover your OLC</string>
-    <string name="welcome_page_text">Discover the Open Location Code of your home.\nOpen Location Codes are free and work with Google Maps.</string>
+    <string name="welcome_page_text">Discover the Plus Code of your home.\nPlus Codes are free and
+    work with Google Maps.</string>
 
     <string name="navigate_button_desc">Navigate from your location to the code</string>
     <string name="share_code_button_desc">Share the code or add to a contact</string>

--- a/c/src/olc_private.h
+++ b/c/src/olc_private.h
@@ -21,9 +21,9 @@ static const char kPaddingCharacter = '0';
 static const char kAlphabet[] = "23456789CFGHJMPQRVWX";
 // Number of digits in the alphabet.
 static const size_t kEncodingBase = OLC_kEncodingBase;
-// The min number of digits returned in a plus code.
+// The min number of digits returned in a Plus Code.
 static const size_t kMinimumDigitCount = 2;
-// The max number of digits returned in a plus code. Roughly 1 x 0.5 cm.
+// The max number of digits returned in a Plus Code. Roughly 1 x 0.5 cm.
 static const size_t kMaximumDigitCount = 15;
 // The number of code characters that are lat/lng pairs.
 static const size_t kPairCodeLength = 10;

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -1,4 +1,4 @@
-# Library to handle open location codes
+# Library to handle Plus Codes
 cc_library(
     name = "openlocationcode",
     srcs = [
@@ -20,7 +20,7 @@ cc_library(
     ],
 )
 
-# Code area library, used by open location codes
+# Code area library, used by Open Location Code
 cc_library(
     name = "codearea",
     srcs = [
@@ -32,7 +32,7 @@ cc_library(
     visibility = ["//visibility:private"],  # Keep private unless needed elsewhere
 )
 
-# Unit test for open location codes
+# Unit test for Open Location Code implementations
 cc_test(
     name = "openlocationcode_test",
     size = "small",
@@ -53,7 +53,7 @@ cc_test(
     testonly = True,
 )
 
-# Example binary for open location codes
+# Example binary for Open Location Code
 cc_binary(
     name = "openlocationcode_example",
     srcs = [

--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -15,7 +15,7 @@ const char kPaddingCharacter = '0';
 const char kAlphabet[] = "23456789CFGHJMPQRVWX";
 // Number of digits in the alphabet.
 const size_t kEncodingBase = 20;
-// The max number of digits returned in a plus code. Roughly 1 x 0.5 cm.
+// The max number of digits returned in a Plus Code. Roughly 1 x 0.5 cm.
 const size_t kMaximumDigitCount = 15;
 const size_t kMinimumDigitCount = 2;
 const size_t kPairCodeLength = 10;

--- a/dart/lib/src/open_location_code.dart
+++ b/dart/lib/src/open_location_code.dart
@@ -39,10 +39,10 @@ const latitudeMax = 90;
 /// The maximum value for longitude in degrees.
 const longitudeMax = 180;
 
-// The min number of digits in a plus code.
+// The min number of digits in a Plus Code.
 const minDigitCount = 2;
 
-// The max number of digits to process in a plus code.
+// The max number of digits to process in a Plus Code.
 const maxDigitCount = 15;
 
 /// Maximum code length using lat/lng pair encoding. The area of such a

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,7 +1,7 @@
 name: open_location_code
-description: Open Location Codes are short, generated codes that can be used like street addresses, for places where street addresses don't exist.
+description: Plus Codes are short, generated codes that can be used like street addresses, for places where street addresses don't exist.
 version: 0.0.1
-homepage: http://openlocationcode.com/
+homepage: https://maps.google.com/pluscodes/
 environment:
   sdk: '^2.19.6'
 dev_dependencies:

--- a/dart/test/utils.dart
+++ b/dart/test/utils.dart
@@ -9,7 +9,7 @@ List<String> getCsvLines(String fileName) {
       .toList();
 }
 
-// Requires test csv files in a test_data directory under open location code project root.
+// Requires test csv files in a test_data directory under Open Location Code project root.
 String testDataPath() {
   var projectRoot = Directory.current.parent;
 

--- a/garmin/PlusCodeDatafield/README.md
+++ b/garmin/PlusCodeDatafield/README.md
@@ -1,17 +1,17 @@
-# Plus code datafield for Garmin Connect IQ devices.
+# Plus Code datafield for Garmin Connect IQ devices
 
 [<img src="https://developer.garmin.com/img/connect-iq/brand/available-badge.svg" alt="Drawing" width=200 style="width: 200px;"/>](https://apps.garmin.com/en-US/apps/74d90879-fbac-48e7-8405-28af2a0a55a7#0)
 
 
-Plus codes are short codes you can use to refer to a place, that are easier
+Plus Codes are short codes you can use to refer to a place, that are easier
 to use than latitude and longitude. They were designed to provide an
 address-like solution for the areas of the world where street addresses do not
-exist or are not widely known. Plus codes are free and the software is open
+exist or are not widely known. Plus Codes are free and the software is open
 source. See the [demo site](https://plus.codes) or the
 [Github project](https://github.com/google/open-location-code).
 
-This datafield displays the plus code for your current location. It doesn't
-use any network because plus codes can be computed offline.
+This datafield displays the Plus Code for your current location. It doesn't
+use any network because Plus Codes can be computed offline.
 
 Codes are displayed with the first four digits (the area code) small, and the
 remaining digits larger (this is the local code).

--- a/garmin/PlusCodeDatafield/resources/strings.xml
+++ b/garmin/PlusCodeDatafield/resources/strings.xml
@@ -1,5 +1,5 @@
 <strings>
-    <string id="AppName">Plus codes</string>
+    <string id="AppName">Plus Codes</string>
     <string id="default_label">plus.codes</string>
     <string id="default_value">---</string>
 </strings>

--- a/garmin/PlusCodeDatafield/source/PlusCodeView.mc
+++ b/garmin/PlusCodeDatafield/source/PlusCodeView.mc
@@ -163,7 +163,7 @@ class PlusCodeView extends Ui.DataField {
   const OLC_ALPHABET = "23456789CFGHJMPQRVWX";
 
   /**
-   * Encode the specified latitude and longitude into a 10 digit plus code using
+   * Encode the specified latitude and longitude into a 10 digit Plus Code using
    * the Open Location Code algorithm. See
    * https://github.com/google/open-location-code
    */

--- a/go/olc.go
+++ b/go/olc.go
@@ -91,7 +91,7 @@ func Check(code string) error {
 	firstSep, firstPad := -1, -1
 	for i, r := range code {
 		if firstPad != -1 {
-			// Open Location Codes with less than eight digits can be suffixed with zeros with a "+" used as the final character. Zeros may not be followed by any other digit.
+			// Plus Code with less than eight digits can be suffixed with zeros with a "+" used as the final character. Zeros may not be followed by any other digit.
 			switch r {
 			case Padding:
 				continue
@@ -112,7 +112,7 @@ func Check(code string) error {
 		}
 		switch r {
 		case 'C', 'F', 'G', 'H', 'J', 'M', 'P', 'Q', 'R', 'V', 'W', 'X',
-			// Processing of Open Location Codes must be case insensitive.
+			// Processing of Plus Codes must be case insensitive.
 			'c', 'f', 'g', 'h', 'j', 'm', 'p', 'q', 'r', 'v', 'w', 'x':
 			continue
 		case Separator:

--- a/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
@@ -19,9 +19,9 @@ import java.util.Objects;
 /**
  * Convert locations to and from convenient short codes.
  *
- * <p>Plus Codes are short, ~10 character codes that can be used instead of street
- * addresses. The codes can be generated and decoded offline, and use a reduced character set that
- * minimises the chance of codes including words.
+ * <p>Plus Codes are short, ~10 character codes that can be used instead of street addresses. The
+ * codes can be generated and decoded offline, and use a reduced character set that minimises the
+ * chance of codes including words.
  *
  * <p>This provides both object and static methods.
  *

--- a/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 /**
  * Convert locations to and from convenient short codes.
  *
- * <p>Open Location Codes are short, ~10 character codes that can be used instead of street
+ * <p>Plus Codes are short, ~10 character codes that can be used instead of street
  * addresses. The codes can be generated and decoded offline, and use a reduced character set that
  * minimises the chance of codes including words.
  *
@@ -57,10 +57,10 @@ public final class OpenLocationCode {
   // The number of characters to place before the separator.
   private static final int SEPARATOR_POSITION = 8;
 
-  // The minimum number of digits in a plus code.
+  // The minimum number of digits in a Plus Code.
   public static final int MIN_DIGIT_COUNT = 2;
 
-  // The max number of digits to process in a plus code.
+  // The max number of digits to process in a Plus Code.
   public static final int MAX_DIGIT_COUNT = 15;
 
   // Maximum code length using just lat/lng pair encoding.

--- a/java/src/test/java/com/google/openlocationcode/PrecisionTest.java
+++ b/java/src/test/java/com/google/openlocationcode/PrecisionTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests size of rectangles defined by open location codes of various size. */
+/** Tests size of rectangles defined by Plus Codes of various size. */
 @RunWith(JUnit4.class)
 public class PrecisionTest {
 

--- a/js/README.md
+++ b/js/README.md
@@ -34,11 +34,11 @@ dependencies, run `eslint` and then run the tests as long as there were no
 eslint errors.
 
 Unit tests are automatically run on pull and push requests and visible at
-https://travis-ci.org/google/open-location-code.
+https://github.com/google/open-location-code/actions.
 
 # Examples
 
-Example web pages illustrating converting map clicks to Open Location Codes,
+Example web pages illustrating converting map clicks with Open Location Code,
 and using Googles Maps API to extend place codes to full codes are in the
 `examples/` directory.
 

--- a/js/closure/openlocationcode.js
+++ b/js/closure/openlocationcode.js
@@ -15,7 +15,7 @@
 /**
   @fileoverview Convert locations to and from short codes.
 
-  Open Location Codes are short, 10-11 character codes that can be used instead
+  Plus Codes are short, 10-11 character codes that can be used instead
   of street addresses. The codes can be generated and decoded offline, and use
   a reduced character set that minimises the chance of codes including words.
 
@@ -360,7 +360,7 @@ function encode(latitude, longitude, optLength) {
   if (optLength < MIN_CODE_LEN ||
       (optLength < PAIR_CODE_LENGTH && optLength % 2 == 1)) {
     throw new Error(
-        'IllegalArgumentException: Invalid Open Location Code length');
+        'IllegalArgumentException: Invalid Plus Code length');
   }
   optLength = Math.min(optLength, MAX_CODE_LEN);
   // Ensure that latitude and longitude are valid.
@@ -438,7 +438,7 @@ function decode(code) {
   if (!isFull(code)) {
     throw new Error(
         'IllegalArgumentException: ' +
-        'Passed Open Location Code is not a valid full code: ' + code);
+        'Passed Plus Code is not a valid full code: ' + code);
   }
   // Strip the '+' and '0' characters from the code and convert to upper case.
   code = code.replace('+', '').replace(/0/g, '').toUpperCase();
@@ -569,7 +569,7 @@ function recoverNearest(
   }
 
   return encode(
-      codeArea.latitudeCenter, codeArea.longitudeCenter, codeArea.codeLength);
+    codeArea.latitudeCenter, codeArea.longitudeCenter, codeArea.codeLength);
 }
 exports.recoverNearest = recoverNearest;
 

--- a/js/closure/openlocationcode.js
+++ b/js/closure/openlocationcode.js
@@ -569,7 +569,7 @@ function recoverNearest(
   }
 
   return encode(
-    codeArea.latitudeCenter, codeArea.longitudeCenter, codeArea.codeLength);
+      codeArea.latitudeCenter, codeArea.longitudeCenter, codeArea.codeLength);
 }
 exports.recoverNearest = recoverNearest;
 

--- a/js/examples/example1.html
+++ b/js/examples/example1.html
@@ -34,7 +34,7 @@
     <div id="messageBox">
       <h1>Convert location to OLC Code</h1>
       <p>
-        Open Location Codes use a grid to encode the location. Each step is
+        Open Location Code uses a grid to encode the location. Each step is
         identified by two letters or numbers, that give the row and column
         number within the grid.
       </p>
@@ -62,7 +62,7 @@
     var clickLatLng = null;
 
     /*
-      Handle clicks on the map. Computes the standard and refined Open Location Codes for
+      Handle clicks on the map. Computes the standard and refined Plus Codes for
       the clicked location, and displays polygons and messages.
     */
     function mapClickHandler(event) {

--- a/js/examples/example2.html
+++ b/js/examples/example2.html
@@ -51,7 +51,7 @@
     var map;
 
     /*
-      Handle clicks on the map. Computes the standard and refined Open Location Codes for
+      Handle clicks on the map. Computes the standard and refined Plus Codes for
       the clicked location.
     */
     function mapClickHandler(event) {

--- a/js/examples/example3.html
+++ b/js/examples/example3.html
@@ -75,7 +75,7 @@
     var localityAddress;
 
     /*
-      Handle clicks on the map. Computes the standard and refined Open Location Codes for
+      Handle clicks on the map. Computes the standard and refined Plus Codes for
       the clicked location.
     */
     function mapClickHandler(event) {

--- a/js/src/openlocationcode.js
+++ b/js/src/openlocationcode.js
@@ -15,7 +15,7 @@
 /**
  * Convert locations to and from short codes.
  *
- * Open Location Codes are short, 10-11 character codes that can be used instead
+ * Plus Codes are short, 10-11 character codes that can be used instead
  * of street addresses. The codes can be generated and decoded offline, and use
  * a reduced character set that minimises the chance of codes including words.
  *
@@ -108,10 +108,10 @@
   // The maximum value for longitude in degrees.
   var LONGITUDE_MAX_ = 180;
 
-  // The min number of digits in a plus code.
+  // The min number of digits in a Plus Code.
   var MIN_DIGIT_COUNT_ = 2;
 
-  // The max number of digits to process in a plus code.
+  // The max number of digits to process in a Plus Code.
   var MAX_DIGIT_COUNT_ = 15;
 
   // Maximum code length using lat/lng pair encoding. The area of such a
@@ -402,7 +402,7 @@
     // point and combined.
     if (!isFull(code)) {
       throw new Error('IllegalArgumentException: ' +
-          'Passed Open Location Code is not a valid full code: ' + code);
+          'Passed Plus Code is not a valid full code: ' + code);
     }
     // Strip the '+' and '0' characters from the code and convert to upper case.
     code = code.replace('+', '').replace(/0/g, '').toLocaleUpperCase('en-US');

--- a/python/openlocationcode/openlocationcode.py
+++ b/python/openlocationcode/openlocationcode.py
@@ -16,7 +16,7 @@
 #
 # Convert locations to and from short codes.
 #
-# Open Location Codes are short, 10-11 character codes that can be used instead
+# Plus Codes are short, 10-11 character codes that can be used instead
 # of street addresses. The codes can be generated and decoded offline, and use
 # a reduced character set that minimises the chance of codes including words.
 #
@@ -81,10 +81,10 @@ LATITUDE_MAX_ = 90
 # The maximum value for longitude in degrees.
 LONGITUDE_MAX_ = 180
 
-# The min number of digits to process in a plus code.
+# The min number of digits to process in a Plus Code.
 MIN_DIGIT_COUNT_ = 2
 
-# The max number of digits to process in a plus code.
+# The max number of digits to process in a Plus Code.
 MAX_DIGIT_COUNT_ = 15
 
 # Maximum code length using lat/lng pair encoding. The area of such a

--- a/ruby/lib/plus_codes.rb
+++ b/ruby/lib/plus_codes.rb
@@ -16,10 +16,10 @@ module PlusCodes
   # The max number of characters can be placed before the separator.
   SEPARATOR_POSITION = 8
 
-  # Minimum number of digits to process in a plus code.
+  # Minimum number of digits to process in a Plus Code.
   MIN_CODE_LENGTH = 2
 
-  # Maximum number of digits to process in a plus code.
+  # Maximum number of digits to process in a Plus Code.
   MAX_CODE_LENGTH = 15
 
   # Maximum code length using lat/lng pair encoding. The area of such a

--- a/rust/src/consts.rs
+++ b/rust/src/consts.rs
@@ -23,10 +23,10 @@ pub const LATITUDE_MAX: f64 = 90f64;
 // The maximum value for longitude in degrees.
 pub const LONGITUDE_MAX: f64 = 180f64;
 
-// Minimum number of digits to process for plus codes.
+// Minimum number of digits to process for Plus Codes.
 pub const MIN_CODE_LENGTH: usize = 2;
 
-// Maximum number of digits to process for plus codes.
+// Maximum number of digits to process for Plus Codes.
 pub const MAX_CODE_LENGTH: usize = 15;
 
 // Maximum code length using lat/lng pair encoding. The area of such a

--- a/tile_server/example.html
+++ b/tile_server/example.html
@@ -50,11 +50,11 @@
     </p>
     <div style="position: relative;">
       <div id="ol_vector_xyz" class="map"></div>
-      <div id="ol_vector_code">Click cell, get plus code</div>
+      <div id="ol_vector_code">Click cell, get Plus Code</div>
     </div>
 
     <script type="text/javascript">
-      // Define the path to the plus code grid server.
+      // Define the path to the Plus Code grid server.
       var gridServer = 'http://localhost:8080/grid/';
     </script>
 
@@ -141,7 +141,7 @@
         gridServer + 'tms/{z}/{x}/{y}.png',
         {
           tms: true,
-          attribution: 'grid by plus codes'
+          attribution: 'grid by Plus Codes'
         }
       ).addTo(llImageMap);
     </script>

--- a/tile_server/gridserver/gridserver.go
+++ b/tile_server/gridserver/gridserver.go
@@ -1,4 +1,4 @@
-// Package gridserver serves tiles with the plus codes grid.
+// Package gridserver serves tiles with the Plus Codes grid.
 // This parses the request, and generates either a GeoJSON or PNG image response.
 package gridserver
 

--- a/visualbasic/OpenLocationCode.bas
+++ b/visualbasic/OpenLocationCode.bas
@@ -16,12 +16,12 @@ Attribute VB_Name = "OpenLocationCode"
 '
 ' Convert locations to and from short codes.
 '
-' Open Location Codes are short, 10-11 character codes that can be used instead
+' Plus Codes are short, 10-11 character codes that can be used instead
 ' of street addresses. The codes can be generated and decoded offline, and use
 ' a reduced character set that minimises the chance of codes including words.
 '
 ' This file provides a VBA implementation (that may also run in OpenOffice or
-' LibreOffice). A full reference of Open Location Codes is provided at
+' LibreOffice). A full reference of Open Location Code is provided at
 ' https://github.com/google/open-location-code.
 '
 ' This library provides the following functions:


### PR DESCRIPTION
This updates mentions of "Open Location Codes" "Plus Codes" and other errors in this repo to instead properly refer to:

1. Mention "Open Location Code" the project, library and API; and
2. Mention "plus codes" referring to the generated codes.

This fixes issue #431.

---

This also fixes a reference to the old URL openlocationcode.com to instead go to its new URL, which I hope is in scope for these name changes.