### PR TITLE
Bump bazel and c testing

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,9 +4,9 @@ module(
 )
 
 bazel_dep(name = "googletest", version = "1.15.2")
-bazel_dep(name = "rules_proto", version = "6.0.2")  # Deprecated (moved), TODO find new URL
+bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "rules_java", version = "7.8.0")
-bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_python", version = "0.33.2")
 
 # External dependency archives

--- a/c/benchmark/bm-c.c
+++ b/c/benchmark/bm-c.c
@@ -13,7 +13,7 @@ static void encode(void) {
   // Encodes latitude and longitude into a Plus+Code.
   location.lat = data_pos_lat;
   location.lon = data_pos_lon;
-  len = OLC_EncodeDefault(&location, code, 256);
+  len = OLC_EncodeDefault(&location, code);
 
   ASSERT_STR_EQ(code, "8FVC2222+22");
   ASSERT_INT_EQ(len, 11);
@@ -27,7 +27,7 @@ static void encode_len(void) {
   // Encodes latitude and longitude into a Plus+Code with a preferred length.
   location.lat = data_pos_lat;
   location.lon = data_pos_lon;
-  len = OLC_Encode(&location, data_pos_len, code, 256);
+  len = OLC_Encode(&location, data_pos_len, code);
 
   ASSERT_STR_EQ(code, "8FVC2222+22GCCCC");
   ASSERT_INT_EQ(len, 16);
@@ -71,7 +71,7 @@ static void shorten(void) {
   OLC_LatLon location;
   location.lat = data_ref_lat;
   location.lon = data_ref_lon;
-  int len = OLC_Shorten(data_code_12, 0, &location, code, 256);
+  int len = OLC_Shorten(data_code_12, 0, &location, code);
 
   ASSERT_STR_EQ(code, "CJ+2VX");
   ASSERT_INT_EQ(len, 6);
@@ -83,7 +83,7 @@ static void recover(void) {
   location.lat = data_ref_lat;
   location.lon = data_ref_lon;
   // Extends a Plus+Code by the given reference latitude and longitude.
-  int len = OLC_RecoverNearest(data_code_6, 0, &location, code, 256);
+  int len = OLC_RecoverNearest(data_code_6, 0, &location, code);
 
   ASSERT_STR_EQ(code, "9C3W9QCJ+2VX");
   ASSERT_INT_EQ(len, 12);

--- a/c/example.c
+++ b/c/example.c
@@ -14,12 +14,12 @@ int main(int argc, char* argv[]) {
   // Encodes latitude and longitude into a Plus+Code.
   location.lat = 47.0000625;
   location.lon = 8.0000625;
-  len = OLC_EncodeDefault(&location, code, 256);
+  len = OLC_EncodeDefault(&location, code);
   printf("%s (%d)\n", code, len);
   // => "8FVC2222+22"
 
   // Encodes latitude and longitude into a Plus+Code with a preferred length.
-  len = OLC_Encode(&location, 16, code, 256);
+  len = OLC_Encode(&location, 16, code);
   printf("%s (%d)\n", code, len);
   // => "8FVC2222+22GCCCC"
 
@@ -49,12 +49,12 @@ int main(int argc, char* argv[]) {
   printf("Original: %s\n", orig);
   location.lat = 51.3708675;
   location.lon = -1.217765625;
-  len = OLC_Shorten(orig, 0, &location, code, 256);
+  len = OLC_Shorten(orig, 0, &location, code);
   printf("Shortened: %s\n", code);
   // => "CJ+2VX"
 
   // Extends a Plus+Code by the given reference latitude and longitude.
-  OLC_RecoverNearest("CJ+2VX", 0, &location, code, 256);
+  OLC_RecoverNearest("CJ+2VX", 0, &location, code);
   printf("Recovered: %s\n", code);
   // => orig
 

--- a/c/openlocationcode_test.cc
+++ b/c/openlocationcode_test.cc
@@ -93,7 +93,7 @@ TEST_P(DecodingChecks, Decode) {
   EXPECT_NEAR(expected_center.lon, got_center.lon, 1e-10);
 }
 
-INSTANTIATE_TEST_CASE_P(OLC_Tests, DecodingChecks,
+INSTANTIATE_TEST_SUITE_P(OLC_Tests, DecodingChecks,
                         ::testing::ValuesIn(GetDecodingDataFromCsv()));
 
 struct EncodingTestData {
@@ -127,11 +127,11 @@ TEST_P(EncodingChecks, Encode) {
   OLC_LatLon loc = OLC_LatLon{test_data.lat_deg, test_data.lng_deg};
   char got_code[18];
   // Encode the test location and make sure we get the expected code.
-  OLC_Encode(&loc, test_data.length, got_code, 18);
+  OLC_Encode(&loc, test_data.length, got_code);
   EXPECT_EQ(test_data.code, got_code);
 }
 
-INSTANTIATE_TEST_CASE_P(OLC_Tests, EncodingChecks,
+INSTANTIATE_TEST_SUITE_P(OLC_Tests, EncodingChecks,
                         ::testing::ValuesIn(GetEncodingDataFromCsv()));
 
 struct ValidityTestData {
@@ -167,7 +167,7 @@ TEST_P(ValidityChecks, Validity) {
   EXPECT_EQ(test_data.is_short, OLC_IsShort(test_data.code.c_str(), 0));
 }
 
-INSTANTIATE_TEST_CASE_P(OLC_Tests, ValidityChecks,
+INSTANTIATE_TEST_SUITE_P(OLC_Tests, ValidityChecks,
                         ::testing::ValuesIn(GetValidityDataFromCsv()));
 
 struct ShortCodeTestData {
@@ -205,18 +205,18 @@ TEST_P(ShortCodeChecks, ShortCode) {
   // Shorten the code using the reference location and check.
   if (test_data.test_type == "B" || test_data.test_type == "S") {
     char got[18];
-    OLC_Shorten(test_data.full_code.c_str(), 0, &reference_loc, got, 18);
+    OLC_Shorten(test_data.full_code.c_str(), 0, &reference_loc, got);
     EXPECT_EQ(test_data.short_code, got);
   }
   // Now extend the code using the reference location and check.
   if (test_data.test_type == "B" || test_data.test_type == "R") {
     char got[18];
-    OLC_RecoverNearest(test_data.short_code.c_str(), 0, &reference_loc, got, 18);
+    OLC_RecoverNearest(test_data.short_code.c_str(), 0, &reference_loc, got);
     EXPECT_EQ(test_data.full_code, got);
   }
 }
 
-INSTANTIATE_TEST_CASE_P(OLC_Tests, ShortCodeChecks,
+INSTANTIATE_TEST_SUITE_P(OLC_Tests, ShortCodeChecks,
                         ::testing::ValuesIn(GetShortCodeDataFromCsv()));
 
 TEST(MaxCodeLengthChecks, MaxCodeLength) {
@@ -254,13 +254,13 @@ TEST(BenchmarkChecks, BenchmarkEncodeDecode) {
     test_data.latlon.lat = lat;
     test_data.latlon.lon = lon;
     test_data.len = len;
-    OLC_Encode(&test_data.latlon, test_data.len, test_data.code, 18);
+    OLC_Encode(&test_data.latlon, test_data.len, test_data.code);
     tests.push_back(test_data);
   }
   char code[18];
   auto start = std::chrono::high_resolution_clock::now();
   for (auto td : tests) {
-    OLC_Encode(&td.latlon, td.len, code, 18);
+    OLC_Encode(&td.latlon, td.len, code);
   }
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
                       std::chrono::high_resolution_clock::now() - start)

--- a/c/src/olc.c
+++ b/c/src/olc.c
@@ -82,8 +82,7 @@ int OLC_IsFull(const char* code, size_t size) {
   return is_full(&info);
 }
 
-int OLC_Encode(const OLC_LatLon* location, size_t length, char* code,
-               int maxlen) {
+int OLC_Encode(const OLC_LatLon* location, size_t length, char* code) {
   // Limit the maximum number of digits in the code.
   if (length > kMaximumDigitCount) {
     length = kMaximumDigitCount;
@@ -159,8 +158,8 @@ int OLC_Encode(const OLC_LatLon* location, size_t length, char* code,
   return char_count;
 }
 
-int OLC_EncodeDefault(const OLC_LatLon* location, char* code, int maxlen) {
-  return OLC_Encode(location, kPairCodeLength, code, maxlen);
+int OLC_EncodeDefault(const OLC_LatLon* location, char* code) {
+  return OLC_Encode(location, kPairCodeLength, code);
 }
 
 int OLC_Decode(const char* code, size_t size, OLC_CodeArea* decoded) {
@@ -172,7 +171,7 @@ int OLC_Decode(const char* code, size_t size, OLC_CodeArea* decoded) {
 }
 
 int OLC_Shorten(const char* code, size_t size, const OLC_LatLon* reference,
-                char* shortened, int maxlen) {
+                char* shortened) {
   CodeInfo info;
   if (analyse(code, size, &info) <= 0) {
     return 0;
@@ -224,7 +223,7 @@ int OLC_Shorten(const char* code, size_t size, const OLC_LatLon* reference,
 }
 
 int OLC_RecoverNearest(const char* short_code, size_t size,
-                       const OLC_LatLon* reference, char* code, int maxlen) {
+                       const OLC_LatLon* reference, char* code) {
   CodeInfo info;
   if (analyse(short_code, size, &info) <= 0) {
     return 0;
@@ -235,7 +234,7 @@ int OLC_RecoverNearest(const char* short_code, size_t size,
     decode(&info, &code_area);
     OLC_LatLon center;
     OLC_GetCenter(&code_area, &center);
-    return OLC_Encode(&center, code_area.len, code, maxlen);
+    return OLC_Encode(&center, code_area.len, code);
   }
   if (!is_short(&info)) {
     return 0;
@@ -261,7 +260,7 @@ int OLC_RecoverNearest(const char* short_code, size_t size,
   // Use the reference location to pad the supplied short code and decode it.
   OLC_LatLon latlon = {lat, lon};
   char encoded[256];
-  OLC_EncodeDefault(&latlon, encoded, 256);
+  OLC_EncodeDefault(&latlon, encoded);
 
   char new_code[256];
   int pos = 0;
@@ -304,7 +303,7 @@ int OLC_RecoverNearest(const char* short_code, size_t size,
     center.lon += resolution;
   }
 
-  return OLC_Encode(&center, len + padding_length, code, maxlen);
+  return OLC_Encode(&center, len + padding_length, code);
 }
 
 // private functions

--- a/c/src/olc.h
+++ b/c/src/olc.h
@@ -54,22 +54,21 @@ int OLC_IsFull(const char* code, size_t size);
 
 // Encode location with given code length (indicates precision) into an OLC
 // Return the string length of the code
-int OLC_Encode(const OLC_LatLon* location, size_t code_length, char* code,
-               int maxlen);
+int OLC_Encode(const OLC_LatLon* location, size_t code_length, char* code);
 
 // Encode location with default code length into an OLC
 // Return the string length of the code
-int OLC_EncodeDefault(const OLC_LatLon* location, char* code, int maxlen);
+int OLC_EncodeDefault(const OLC_LatLon* location, char* code);
 
 // Decode OLC into the original location
 int OLC_Decode(const char* code, size_t size, OLC_CodeArea* decoded);
 
 // Compute a (shorter) OLC for a given code and a reference location
 int OLC_Shorten(const char* code, size_t size, const OLC_LatLon* reference,
-                char* buf, int maxlen);
+                char* buf);
 
 // Given shorter OLC and reference location, compute original (full length) OLC
 int OLC_RecoverNearest(const char* short_code, size_t size,
-                       const OLC_LatLon* reference, char* code, int maxlen);
+                       const OLC_LatLon* reference, char* code);
 
 #endif


### PR DESCRIPTION
Remove unused param to fix warnings.

Bump bazel testing to fix warnings.

All for C implementation.