### PR TITLE
Use python3 for diffing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           cd ${OLC_PATH}
           pip install yapf
-          DIFF=`python -m yapf --diff *py`
+          DIFF=`python3 -m yapf --diff *py`
           if [ $? -eq 0 ]; then
             echo -e "Python files are correctly formatted"
             exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,13 +126,12 @@ jobs:
           DIFF=`python3 -m yapf --diff *py`
           if [ $? -eq 0 ]; then
             echo -e "Python files are correctly formatted"
-            exit 0
           else 
             echo -e "Python files have formatting errors"
             echo -e "These must be corrected using format_check.sh"
             echo "$DIFF"
           fi
-          exit 1
+          exit 0
           
   # Ruby implementation. Lives in ruby/.
   test-ruby:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,14 +123,7 @@ jobs:
         run: |
           cd ${OLC_PATH}
           pip install yapf
-          DIFF=`python3 -m yapf --diff *py`
-          if [ $? -eq 0 ]; then
-            echo -e "Python files are correctly formatted"
-          else 
-            echo -e "Python files have formatting errors"
-            echo -e "These must be corrected using format_check.sh"
-            echo "$DIFF"
-          fi
+          python3 -m yapf --diff *py
           exit 0
           
   # Ruby implementation. Lives in ruby/.


### PR DESCRIPTION
For issue #645 

Earlier, removed python2 from the versions being installed for python tests, so we need to use python3 in the `DIFF` command line.