### PR TITLE
Updates for bazelisk support

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,5 @@
+# Set options for Bazelisk, a wrapper for Bazel.
+
+# Set the version of Bazel to use.
+# TODO: #642 -- Update once the JS bazelbuild/rules_closure supports bazel modules.
+USE_BAZEL_VERSION=7.4.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
       OLC_PATH: c
     steps:
       - uses: actions/checkout@v2
+      - uses: bazelbuild/setup-bazelisk@v3
       - name: test
         run: bazel test --test_output=all ${OLC_PATH}:all
       - name: check formatting
@@ -20,6 +21,7 @@ jobs:
       OLC_PATH: cpp
     steps:
       - uses: actions/checkout@v2
+      - uses: bazelbuild/setup-bazelisk@v3
       - name: test
         run: bazel test --test_output=all ${OLC_PATH}:all
       - name: check formatting
@@ -70,6 +72,7 @@ jobs:
     name: test-java-${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
+      - uses: bazelbuild/setup-bazelisk@v3
       - name: Setup java
         uses: actions/setup-java@v2
         with:
@@ -85,6 +88,7 @@ jobs:
       OLC_PATH: js/closure
     steps:
       - uses: actions/checkout@v2
+      - uses: bazelbuild/setup-bazelisk@v3
       - name: test
         run: |
           bazel test ${OLC_PATH}:all
@@ -113,6 +117,7 @@ jobs:
     name: test-python-${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2
+      - uses: bazelbuild/setup-bazelisk@v3
       - name: Set up Python 
         uses: actions/setup-python@v2
         with:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,16 +8,3 @@ bazel_dep(name = "rules_proto", version = "6.0.2")  # Deprecated (moved), TODO f
 bazel_dep(name = "rules_java", version = "7.8.0")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "rules_python", version = "0.33.2")
-
-# External dependency archives
-http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "io_bazel_rules_closure",
-    sha256 = "9498e57368efb82b985db1ed426a767cbf1ba0398fd7aed632fc3908654e1b1e",
-    strip_prefix = "rules_closure-0.12.0",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.12.0.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/0.12.0.tar.gz",
-    ],
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,19 @@
+# Workspace configuration for Bazel build tools.
+
+# TODO: #642 -- Remove once io_bazel_rules_closure supports Bazel module configuration.
+workspace(name = "openlocationcode")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_closure",
+    integrity = "sha256-EvEWnr54L4Yx/LjagaoSuhkviVKHW0oejyDEn8bhAiM=",
+    strip_prefix = "rules_closure-0.14.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.14.0.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/0.14.0.tar.gz",
+    ],
+)
+load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
+rules_closure_dependencies()
+rules_closure_toolchains()

--- a/js/closure/BUILD
+++ b/js/closure/BUILD
@@ -19,10 +19,10 @@ closure_js_test(
     entry_points = ["goog:openlocationcode_test"],
     deps = [
         ":openlocationcode_lib",
-        "@io_bazel_rules_closure//closure/library/net:eventtype",
-        "@io_bazel_rules_closure//closure/library/net:xhrio",
-        "@io_bazel_rules_closure//closure/library/testing:asserts",
-        "@io_bazel_rules_closure//closure/library/testing:asynctestcase",
-        "@io_bazel_rules_closure//closure/library/testing:testsuite",
+        "@com_google_javascript_closure_library//closure/goog/net:eventtype",
+        "@com_google_javascript_closure_library//closure/goog/net:xhrio",
+        "@com_google_javascript_closure_library//closure/goog/testing:asserts",
+        "@com_google_javascript_closure_library//closure/goog/testing:asynctestcase",
+        "@com_google_javascript_closure_library//closure/goog/testing:testsuite",
     ],
 )

--- a/js/closure/openlocationcode_test.js
+++ b/js/closure/openlocationcode_test.js
@@ -28,13 +28,13 @@ const testSuite = goog.require('goog.testing.testSuite');
 goog.require('goog.testing.asserts');
 
 const /** @const {string} */ DECODING_TEST_FILE =
-    '/filez/openlocationcode/test_data/decoding.csv';
+    '/filez/_main/test_data/decoding.csv';
 const /** @const {string} */ ENCODING_TEST_FILE =
-    '/filez/openlocationcode/test_data/encoding.csv';
+    '/filez/_main/test_data/encoding.csv';
 const /** @const {string} */ SHORT_CODE_TEST_FILE =
-    '/filez/openlocationcode/test_data/shortCodeTests.csv';
+    '/filez/_main/test_data/shortCodeTests.csv';
 const /** @const {string} */ VALIDITY_TEST_FILE =
-    '/filez/openlocationcode/test_data/validityTests.csv';
+    '/filez/_main/test_data/validityTests.csv';
 
 // Initialise the async test framework.
 const /** @const {!AsyncTestCase} */ asyncTestCase = AsyncTestCase.createAndInstall();


### PR DESCRIPTION
For issue #659 

This adds an action to use `bazelisk` to fetch a specific `bazel` version, configured to 7.4.1 in the `.bazeliskrc` file.

It adds back the `WORKSPACE` file, since the Bazel Closure Rules package does not support the new bazel modules.

Finally it updates the dependencies for the JS Closure test, and the path to the test data files.