### PR TITLE
Update Bazel module versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,13 +3,11 @@ module(
     version = "1.0",
 )
 
-# https://github.com/google/googletest
-bazel_dep(name = "googletest", version = "1.15.2")
-# https://github.com/bazelbuild/rules_proto
-bazel_dep(name = "rules_proto", version = "7.1.0")
-# https://github.com/bazelbuild/rules_java
-bazel_dep(name = "rules_java", version = "8.6.3")
+# bazel-skylib required by #@io_bazel_rules_closure.
 # https://github.com/bazelbuild/bazel-skylib
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-# https://github.com/bazelbuild/rules_python
-bazel_dep(name = "rules_python", version = "1.0.0")
+
+# googletest required by c/BUILD.
+# https://github.com/google/googletest
+bazel_dep(name = "googletest", version = "1.15.2")
+

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,8 +3,13 @@ module(
     version = "1.0",
 )
 
+# https://github.com/google/googletest
 bazel_dep(name = "googletest", version = "1.15.2")
-bazel_dep(name = "rules_proto", version = "6.0.2")  # Deprecated (moved), TODO find new URL
-bazel_dep(name = "rules_java", version = "7.8.0")
-bazel_dep(name = "bazel_skylib", version = "1.6.1")
-bazel_dep(name = "rules_python", version = "0.33.2")
+# https://github.com/bazelbuild/rules_proto
+bazel_dep(name = "rules_proto", version = "7.1.0")
+# https://github.com/bazelbuild/rules_java
+bazel_dep(name = "rules_java", version = "8.6.3")
+# https://github.com/bazelbuild/bazel-skylib
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+# https://github.com/bazelbuild/rules_python
+bazel_dep(name = "rules_python", version = "1.0.0")


### PR DESCRIPTION
Issue #659 

Update module versions in Bazel configuration to latest, and remove the ones that aren't necessary.