### PR TITLE
Change Travis mentions to "CI" or remove as appropriate

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-# Reduce OOM errors on TravisCI
+# Reduce OOM errors on CI
 startup --host_jvm_args=-Xms500m
 startup --host_jvm_args=-Xmx500m
 startup --host_jvm_args=-XX:-UseParallelGC

--- a/c/clang_check.sh
+++ b/c/clang_check.sh
@@ -22,13 +22,8 @@ RETURN=0
 for FILE in `ls *.[ch] */*.[ch]`; do
   DIFF=`diff $FILE <($CLANG_FORMAT $FILE)`
   if [ $? -ne 0 ]; then
-    if [ -z "$TRAVIS" ]; then
-      echo "Formatting $FILE" >&2
-      $CLANG_FORMAT -i $FILE
-    else
-      echo -e "\e[31m$FILE has formatting errors:\e[30m" >&2
-      echo "$DIFF" >&2
-    fi
+    echo "Formatting $FILE" >&2
+    $CLANG_FORMAT -i $FILE
     RETURN=1
   fi
 done

--- a/cpp/clang_check.sh
+++ b/cpp/clang_check.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Check formatting of C++ source files using clang-format.
-# If running on TravisCI, will display the lines that need changing,
-# otherwise it will format the files in place.
+# It will format the files in place.
 
 CLANG_FORMAT="clang-format-5.0"
 if hash $CLANG_FORMAT 2>/dev/null; then
@@ -25,13 +24,8 @@ RETURN=0
 for FILE in `ls *.cc *.h`; do
   DIFF=`diff $FILE <($CLANG_FORMAT $FILE)`
   if [ $? -ne 0 ]; then
-    if [ -z "$TRAVIS" ]; then
-      echo "Formatting $FILE" >&2
-      $CLANG_FORMAT -i $FILE
-    else
-      echo -e "\e[31m$FILE has formatting errors:\e[30m" >&2
-      echo "$DIFF" >&2
-    fi
+    echo "Formatting $FILE" >&2
+    $CLANG_FORMAT -i $FILE
     RETURN=1
   fi
 done

--- a/dart/README.md
+++ b/dart/README.md
@@ -10,12 +10,10 @@ To format your files, just run `format_check.sh` or:
 dartfmt --fix --overwrite .
 ```
 
-The TravisCI test **will fail if any files need formatting**.
-
 ## Hints
 
-The TravisCI test uses `dartanalyzer` to check the library for improvements. IF
-any are found the TravisCI tests **will fail**.
+The CI test uses `dartanalyzer` to check the library for improvements. IF
+any are found the CI tests **will fail**.
 
 ## Testing
 

--- a/dart/checks.sh
+++ b/dart/checks.sh
@@ -22,36 +22,16 @@ RETURN=0
 for FILE in `find * | egrep "\.dart$"`; do
   FORMATTED=`$DART_FMT_CMD --set-exit-if-changed --fix "$FILE"`
   if [ $? -ne 0 ]; then
-    if [ -z "$TRAVIS" ]; then
-      # Running locally, we can just format the file. Use colour codes.
-      echo -e "\e[1;34m"
-      $DART_FMT_CMD --fix --overwrite $FILE
-      echo -e "\e[0m"
-    else
-      # On TravisCI, send a comment with the diff to the pull request.
-      DIFF=`echo "$FORMATTED" | diff $FILE -`
-      echo -e "\e[1;31mFile has formatting errors: $FILE\e[0m"
-      echo "$DIFF"
-      RETURN=1
-      go run ../travis-utils/github_comments.go --pr "$TRAVIS_PULL_REQUEST" \
-          --comment '**File has `dartfmt` errors that must be fixed**. Here is a diff, or run `checks.sh`:'"<br><pre>$DIFF</pre>" \
-          --file "dart/$FILE" \
-          --commit "$TRAVIS_PULL_REQUEST_SHA"
-    fi
+    # Running locally, we can just format the file. Use colour codes.
+    echo -e "\e[1;34m"
+    $DART_FMT_CMD --fix --overwrite $FILE
+    echo -e "\e[0m"
   fi
   ANALYSIS=`$DART_ANALYZER_CMD "$FILE"`
   echo "$ANALYSIS" | grep "No issues found" >/dev/null
   if [ $? -ne 0 ]; then
     echo -e "\e[1;31mStatic analysis problems: $FILE\e[0m"
     echo "$ANALYSIS"
-    if [ "$TRAVIS" != "" ]; then
-      # On TravisCI, send a comment with the diff to the pull request.
-      RETURN=1
-      go run ../travis-utils/github_comments.go --pr "$TRAVIS_PULL_REQUEST" \
-          --comment '**File has `dartanalyzer` errors that must be addressed**:'"<br><pre>$ANALYSIS</pre>" \
-          --file "dart/$FILE" \
-          --commit "$TRAVIS_PULL_REQUEST_SHA"
-    fi
   fi
 done
 

--- a/js/README.md
+++ b/js/README.md
@@ -34,7 +34,7 @@ dependencies, run `eslint` and then run the tests as long as there were no
 eslint errors.
 
 Unit tests are automatically run on pull and push requests and visible at
-https://travis-ci.org/google/open-location-code.
+https://github.com/google/open-location-code/actions.
 
 # Examples
 

--- a/js/checks.sh
+++ b/js/checks.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # Run lint checks on files in the Javascript directory.
-# When running within TravisCI, post comments back to the pull request.
 # Also converts the test CSV files to JSON ready for the tests to execute.
 # Note: must run within the JS directory.
 if [ `basename "$PWD"` != "js" ]; then
@@ -46,14 +45,6 @@ else
     echo -e "\e[1;31mFile has formatting errors:\e[0m"
     echo "$LINT"
     RETURN=1
-    if [ -v TRAVIS ]; then
-      # On TravisCI, send a comment with the diff to the pull request.
-      go run ../travis-utils/github_comments.go \
-          --comment '**File has `eslint` errors that must be fixed**:'"<br><pre>$LINT</pre>" \
-          --file "js/$FILE" \
-          --pr "$TRAVIS_PULL_REQUEST" \
-          --commit "$TRAVIS_PULL_REQUEST_SHA"
-    fi
   fi
 fi
 exit $RETURN

--- a/js/closure/README.md
+++ b/js/closure/README.md
@@ -24,8 +24,7 @@ npm install eslint
 eslint closure/*js
 ```
 
-If there are any syntax or style errors, it will output messages. Note that
-syntax or style errors will cause the TravisCI tests to **fail**.
+If there are any syntax or style errors, it will output messages.
 
 ## Building and Testing
 

--- a/python/README.md
+++ b/python/README.md
@@ -44,7 +44,7 @@ bash format_check.sh
 
 If you just want to see the changes, you can run `python -m yapf --diff *py`
 
-This script runs as part of the TravisCI tests - if files need formatting it
+This script runs as part of the CI tests - if files need formatting it
 will display the required changes **and fail the test**.
 
 

--- a/python/format_check.sh
+++ b/python/format_check.sh
@@ -13,13 +13,7 @@ if [ $? -eq 0 ]; then
   exit 0
 fi
 
-if [ -z "$TRAVIS" ]; then
-  # Not running on TravisCI, so format the files in place.
-  echo -e "\e[34mPython files have formatting errors -formatting in place\e[30m"
-  python -m yapf --in-place *py
-else
-  echo -e "\e[31mPython files have formatting errors\e[30m"
-  echo -e "\e[31mThese must be corrected using format_check.sh\e[30m"
-  echo "$DIFF"
-fi
+# Format the files in place.
+echo -e "\e[34mPython files have formatting errors -formatting in place\e[30m"
+python -m yapf --in-place *py
 exit 1

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -20,7 +20,7 @@ gem install rubocop
 rubocop --config rubocop.yml
 ```
 
-If you can't run it yourself, it is run as part of the TravisCI tests.
+If you can't run it yourself, it is run as part of the CI tests.
 
 
 ### Testing

--- a/rust/README.md
+++ b/rust/README.md
@@ -6,7 +6,7 @@ This is the Rust implementation of the Open Location Code library.
 
 Code must be formatted with `rustfmt`. You can do this by running `cargo fmt`.
 
-The formatting will be checked in the TravisCI integration tests. If the files
+The formatting will be checked in the CI integration tests. If the files
 need formatting the tests will fail.
 
 ## Testing


### PR DESCRIPTION
This removes dead code for Travis CI which has not run in years. Updates wording mentioning TravisCI to instead mention CI.