### PR TITLE
Remove a broken examples link from js/README.md

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -42,8 +42,6 @@ Example web pages illustrating converting map clicks with Open Location Code,
 and using Googles Maps API to extend place codes to full codes are in the
 `examples/` directory.
 
-More examples are on [jsfiddle](https://jsfiddle.net/user/openlocationcode/fiddles/).
-
 # Public Methods
 
 The following are the four public methods and one object you should use. All the


### PR DESCRIPTION
The current jsfiddle link is not working. Let's remove it.
https://jsfiddle.net/user/openlocationcode/fiddles/