### PR TITLE
Modify integer conversion for Go library

### DIFF
--- a/go/decode.go
+++ b/go/decode.go
@@ -90,7 +90,7 @@ func Decode(code string) (CodeArea, error) {
 	// Everything is ints so they all need to be cast to floats.
 	lat := float64(normalLat)/pairPrecision + float64(extraLat)/finalLatPrecision
 	lng := float64(normalLng)/pairPrecision + float64(extraLng)/finalLngPrecision
-	// Round everthing off to 14 places.
+	// Round everything off to 14 places.
 	return CodeArea{
 		LatLo: math.Round(lat*1e14) / 1e14,
 		LngLo: math.Round(lng*1e14) / 1e14,

--- a/go/olc.go
+++ b/go/olc.go
@@ -231,10 +231,6 @@ func clipLatitude(lat float64) float64 {
 	return lat
 }
 
-func normalizeLat(value float64) float64 {
-	return normalize(value, latMax)
-}
-
 func normalizeLng(value float64) float64 {
 	return normalize(value, lngMax)
 }

--- a/go/olc_test.go
+++ b/go/olc_test.go
@@ -47,9 +47,9 @@ type (
 	}
 
 	decodingTest struct {
-		code                                 string
-		length                               int
-		lat, lng, latLo, lngLo, latHi, lngHi float64
+		code                       string
+		length                     int
+		latLo, lngLo, latHi, lngHi float64
 	}
 
 	shortenTest struct {
@@ -78,9 +78,7 @@ func init() {
 
 	go func() {
 		defer wg.Done()
-		for _, cols := range append(
-			mustReadLines("encoding.csv"),
-		) {
+		for _, cols := range mustReadLines("encoding.csv") {
 			encoding = append(encoding, encodingTest{
 				lat:    mustFloat(cols[0]),
 				lng:    mustFloat(cols[1]),
@@ -92,9 +90,7 @@ func init() {
 
 	go func() {
 		defer wg.Done()
-		for _, cols := range append(
-			mustReadLines("decoding.csv"),
-		) {
+		for _, cols := range mustReadLines("decoding.csv") {
 			decoding = append(decoding, decodingTest{
 				code:   cols[0],
 				length: mustInt(cols[1]),


### PR DESCRIPTION
For issue https://github.com/google/open-location-code/issues/672

This modifies the integer conversion in the Go implementation to resolve floating point precision inconsistencies.

It doesn't yet expose the integer-based encoding as a separate function as I'm hopeful we can resolve our problems without having to do that.

It also cleans up a bunch of static analysis warnings (unused code etc).