### PR TITLE
modify integer conversion for PostgreSQL implementation

### DIFF
--- a/plpgsql/README.md
+++ b/plpgsql/README.md
@@ -1,38 +1,48 @@
 # Open Location Code PL/SQL
+
 This is the pl/sql implementation of the Open Location Code.
 
 The library file is in `pluscode_functions.sql`.
 
 All functions are installed in the public Schema.
 
-# Tests
+## Tests
 
-Unit tests require docker,
-[DockerDesktop](https://www.docker.com/)
+Unit tests require [Docker](https://www.docker.com/) to be installed.
 
-Download the pluscode_functions.sql file.
+Download the `pluscode_functions.sql` and `tests_script_l.sql` files.
 
-Download the tests_script_l.sql file.
+Start a [PostgreSQL Docker](https://hub.docker.com/_/postgres) image and copy the Open Location Code files to it:
 
-Before run the tests :
+1. Download and run a PostgreSQL image. Call it `pgtest` and run on port 5433:
 
-A - Upload and run postgresql image name : pgtest port 5433
-`docker run --name pgtest -e POSTGRES_PASSWORD=postgres -d -p 5433:5432 postgres`
+    ```shell
+    docker run --name pgtest -e POSTGRES_PASSWORD=postgres -d -p 5433:5432 postgres
+    ```
 
-B - COPY file with olc functions in the container
-`docker cp c:/path/to/file/pluscode_functions.sql pgtest:/pluscode_functions.sql`
+1. Copy the Open Location Code files to the container and change the permissions to allow the `postgres` user to read them:
 
-C - COPY file with Tests in the container
-`docker cp c:/path/to/file/tests_script_l.sql pgtest:/tests_script_l.sql`
+    ```shell
+    docker cp pluscode_functions.sql pgtest:/pluscode_functions.sql
+    docker cp tests_script_l.sql pgtest:/tests_script_l.sql
+    sudo docker exec pgtest chmod a+r *.sql
+    ```
 
-D - Execute openlocation.sql in db
-`docker exec -u postgres pgtest psql postgres postgres -f ./pluscode_functions.sql`
+1. Execute the SQL that defines the functions in the db:
 
-Then Execute tests script
-`docker exec -u postgres pgtest psql postgres postgres -f ./tests_script_l.sql`
+    ```shell
+    docker exec -u postgres pgtest psql postgres postgres -f ./pluscode_functions.sql
+    ```
 
+1. Execute tests script
 
-## pluscode_encode()
+    ```shell
+    docker exec -u postgres pgtest psql postgres postgres -f ./tests_script_l.sql
+    ```
+
+## Functions
+
+### pluscode_encode()
 
 ```sql
 pluscode_encode(latitude, longitude, codeLength) → {string}
@@ -48,7 +58,7 @@ Encode a location into an Open Location Code.
 | `longitude` | `number` |
 | `codeLength` | `number` |
 
-## pluscode_decode()
+### pluscode_decode()
 
 ```sql
 pluscode_decode(code) → {codearea record}
@@ -66,8 +76,7 @@ Decodes an Open Location Code into its location coordinates.
 
 The `CodeArea` record.
 
-
-## pluscode_shorten()
+### pluscode_shorten()
 
 ```sql
 pluscode_shorten(code, latitude, longitude) → {string}
@@ -88,8 +97,7 @@ Remove characters from the start of an OLC code.
 The code, shortened as much as possible that it is still the closest matching
 code to the reference location.
 
-
-## pluscode_recoverNearest()
+### pluscode_recoverNearest()
 
 ```sql
 pluscode_recoverNearest(shortCode, referenceLatitude, referenceLongitude) → {string}

--- a/plpgsql/pluscode_functions.sql
+++ b/plpgsql/pluscode_functions.sql
@@ -351,15 +351,24 @@ BEGIN
 
     codeLength := LEAST(codeLength, MAX_DIGIT_COUNT_);
 
-    latitude := pluscode_clipLatitude(latitude);
-    longitude := pluscode_normalizeLongitude(longitude);
-
-    IF (latitude = 90) THEN
-        latitude := latitude - pluscode_computeLatitudePrecision(codeLength);
-    END IF;
-
     latVal := floor(round((latitude + LATITUDE_MAX_) * FINAL_LAT_PRECISION_, 6));
     lngVal := floor(round((longitude + LONGITUDE_MAX_) * FINAL_LNG_PRECISION_, 6));
+
+    latVal := round(latitude * FINAL_LAT_PRECISION_);
+    latVal := latVal + LATITUDE_MAX_ * FINAL_LAT_PRECISION_;
+    IF (latVal < 0) THEN
+        latVal := 0;
+    ELSIF (latVal > 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_) THEN
+        latVal := 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_ - 1;
+    END IF;
+
+    lngVal := round(longitude * FINAL_LNG_PRECISION_);
+    lngVal := lngVal + LONGITUDE_MAX_ * FINAL_LNG_PRECISION_;
+    IF (lngVal < 0) THEN
+        lngVal := lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_) + 2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_;
+    ELSIF (lngVal > 2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_) THEN
+        lngVal :=  lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_);
+    END IF;
 
     IF (codeLength > PAIR_CODE_LENGTH_) THEN
         i_ := 0;


### PR DESCRIPTION
For issue https://github.com/google/open-location-code/issues/672

This modifies the integer conversion in the PostgreSQL implementation to resolve floating point precision inconsistencies.

It doesn't yet expose the integer-based encoding as a separate function as I'm hopeful we can resolve our problems without having to do that.

It also updates the testing section of the README.md.