### PR TITLE
remove rounding in decode results

### DIFF
--- a/js/closure/openlocationcode.js
+++ b/js/closure/openlocationcode.js
@@ -497,12 +497,11 @@ function decode(code) {
   // Merge the values from the normal and extra precision parts of the code.
   var lat = normalLat / PAIR_PRECISION + gridLat / FINAL_LAT_PRECISION;
   var lng = normalLng / PAIR_PRECISION + gridLng / FINAL_LNG_PRECISION;
-  // Multiple values by 1e14, round and then divide. This reduces errors due
-  // to floating point precision.
   return new CodeArea(
-      Math.round(lat * 1e14) / 1e14, Math.round(lng * 1e14) / 1e14,
-      Math.round((lat + latPrecision) * 1e14) / 1e14,
-      Math.round((lng + lngPrecision) * 1e14) / 1e14,
+      lat,
+      lng,
+      lat + latPrecision,
+      lng + lngPrecision,
       Math.min(code.length, MAX_CODE_LEN));
 }
 exports.decode = decode;

--- a/js/src/openlocationcode.js
+++ b/js/src/openlocationcode.js
@@ -460,12 +460,11 @@
     // Merge the values from the normal and extra precision parts of the code.
     var lat = normalLat / PAIR_PRECISION_ + gridLat / FINAL_LAT_PRECISION_;
     var lng = normalLng / PAIR_PRECISION_ + gridLng / FINAL_LNG_PRECISION_;
-    // Multiple values by 1e14, round and then divide. This reduces errors due
-    // to floating point precision.
     return new CodeArea(
-        Math.round(lat * 1e14) / 1e14, Math.round(lng * 1e14) / 1e14,
-        Math.round((lat + latPrecision) * 1e14) / 1e14,
-        Math.round((lng + lngPrecision) * 1e14) / 1e14,
+        lat,
+        lng,
+        lat + latPrecision,
+        lng + lngPrecision,
         Math.min(code.length, MAX_DIGIT_COUNT_));
   };
 


### PR DESCRIPTION
For issue #710 

JS implementations round the coordinates in the results from `Decode()`. If this is to enable tests to pass then that should be done in the tests, not by fudging the actual return values.