### PR TITLE
Split encoding implementations into integer encoding method

### DIFF
--- a/c/src/olc.h
+++ b/c/src/olc.h
@@ -22,29 +22,42 @@
 #define OLC_MAKE_VERSION_STR(major, minor, patch) \
   OLC_MAKE_VERSION_STR_IMPL(major, minor, patch)
 
-// Current version, as a number and a string
+// Current version, as a number and a string.
 #define OLC_VERSION_NUM \
   OLC_MAKE_VERSION_NUM(OLC_VERSION_MAJOR, OLC_VERSION_MINOR, OLC_VERSION_PATCH)
 #define OLC_VERSION_STR \
   OLC_MAKE_VERSION_STR(OLC_VERSION_MAJOR, OLC_VERSION_MINOR, OLC_VERSION_PATCH)
 
-// A pair of doubles representing latitude / longitude
+// A pair of doubles representing latitude and longitude.
 typedef struct OLC_LatLon {
   double lat;
   double lon;
 } OLC_LatLon;
 
-// An area defined by two corners (lo and hi) and a code length
+// A pair of clipped, normalised positive range integers representing latitude
+// and longitude. This is used internally in the encoding methods to avoid
+// floating-point precision issues.
+typedef struct OLC_LatLonIntegers {
+  long long int lat;
+  long long int lon;
+} OLC_LatLonIntegers;
+
+// Convert a location in degrees into the integer values necessary to reliably
+// encode it.
+void OLC_LocationToIntegers(const OLC_LatLon* degrees,
+                            OLC_LatLonIntegers* integers);
+
+// An area defined by two corners (lo and hi) and a code length.
 typedef struct OLC_CodeArea {
   OLC_LatLon lo;
   OLC_LatLon hi;
   size_t len;
 } OLC_CodeArea;
 
-// Get the center coordinates for an area
+// Get the center coordinates for an area.
 void OLC_GetCenter(const OLC_CodeArea* area, OLC_LatLon* center);
 
-// Get the effective length for a code
+// Get the effective length for a code.
 size_t OLC_CodeLength(const char* code, size_t size);
 
 // Check for the three obviously-named conditions
@@ -52,23 +65,28 @@ int OLC_IsValid(const char* code, size_t size);
 int OLC_IsShort(const char* code, size_t size);
 int OLC_IsFull(const char* code, size_t size);
 
-// Encode location with given code length (indicates precision) into an OLC
-// Return the string length of the code
+// Encode location with given code length (indicates precision) into an OLC.
+// Return the string length of the code.
 int OLC_Encode(const OLC_LatLon* location, size_t code_length, char* code,
                int maxlen);
 
-// Encode location with default code length into an OLC
-// Return the string length of the code
+// Encode using integer values. This is only exposed for testing and should
+// not be called from client code.
+int OLC_EncodeIntegers(const OLC_LatLonIntegers* location, size_t code_length,
+                       char* code, int maxlen);
+
+// Encode location with default code length into an OLC.
+// Return the string length of the code.
 int OLC_EncodeDefault(const OLC_LatLon* location, char* code, int maxlen);
 
-// Decode OLC into the original location
+// Decode OLC into the original location.
 int OLC_Decode(const char* code, size_t size, OLC_CodeArea* decoded);
 
-// Compute a (shorter) OLC for a given code and a reference location
+// Compute a (shorter) OLC for a given code and a reference location.
 int OLC_Shorten(const char* code, size_t size, const OLC_LatLon* reference,
                 char* buf, int maxlen);
 
-// Given shorter OLC and reference location, compute original (full length) OLC
+// Given shorter OLC and reference location, compute original (full length) OLC.
 int OLC_RecoverNearest(const char* short_code, size_t size,
                        const OLC_LatLon* reference, char* code, int maxlen);
 

--- a/cpp/openlocationcode.h
+++ b/cpp/openlocationcode.h
@@ -106,6 +106,12 @@ extern const size_t kInitialExponent;
 // Size of the initial grid in degrees. This is the size of the area represented
 // by a 10 character code, and is kEncodingBase ^ (2 - kPairCodeLength / 2).
 extern const double kGridSizeDegrees;
+// Internal method to convert latitude in degrees to the integer value for encoding.
+int64_t latitudeToInteger(double latitude);
+// Internal method to convert longitude in degrees to the integer value for encoding.
+int64_t longitudeToInteger(double longitude);
+// Internal method to encode using the integer values to avoid floating-point precision errors.
+std::string encodeIntegers(int64_t latitude, int64_t longitude, size_t code_length);
 }  // namespace internal
 
 }  // namespace openlocationcode

--- a/cpp/openlocationcode.h
+++ b/cpp/openlocationcode.h
@@ -106,12 +106,16 @@ extern const size_t kInitialExponent;
 // Size of the initial grid in degrees. This is the size of the area represented
 // by a 10 character code, and is kEncodingBase ^ (2 - kPairCodeLength / 2).
 extern const double kGridSizeDegrees;
-// Internal method to convert latitude in degrees to the integer value for encoding.
+// Internal method to convert latitude in degrees to the integer value for
+// encoding.
 int64_t latitudeToInteger(double latitude);
-// Internal method to convert longitude in degrees to the integer value for encoding.
+// Internal method to convert longitude in degrees to the integer value for
+// encoding.
 int64_t longitudeToInteger(double longitude);
-// Internal method to encode using the integer values to avoid floating-point precision errors.
-std::string encodeIntegers(int64_t latitude, int64_t longitude, size_t code_length);
+// Internal method to encode using the integer values to avoid floating-point
+// precision errors.
+std::string encodeIntegers(int64_t latitude, int64_t longitude,
+                           size_t code_length);
 }  // namespace internal
 
 }  // namespace openlocationcode

--- a/dart/lib/src/open_location_code.dart
+++ b/dart/lib/src/open_location_code.dart
@@ -259,11 +259,13 @@ String encode(num latitude, num longitude, {int codeLength = pairCodeLength}) {
     throw ArgumentError('Invalid Open Location Code length: $codeLength');
   }
   codeLength = min(maxDigitCount, codeLength);
+  var integers = locationToIntegers(latitude, longitude);
+  return encodeIntegers(integers[0], integers[1], codeLength);
+}
 
-  // This approach converts each value to an integer after multiplying it by
-  // the final precision. This allows us to use only integer operations, so
-  // avoiding any accumulation of floating point representation errors.
-
+// Convert latitude and longitude in degrees to the integer values needed for
+// reliable conversions.
+List<int> locationToIntegers(num latitude, num longitude) {
   // Convert latitude into a positive integer clipped into the range 0-(just
   // under 180*2.5e7). Latitude 90 needs to be adjusted to be just less, so the
   // returned code can also be decoded.
@@ -286,7 +288,11 @@ String encode(num latitude, num longitude, {int codeLength = pairCodeLength}) {
   } else if (lngVal >= 2 * longitudeMax * finalLngPrecision) {
     lngVal = lngVal % (2 * longitudeMax * finalLngPrecision);
   }
+  return [latVal, lngVal];
+}
 
+/// Encode a location into an Open Location Code.
+String encodeIntegers(int latVal, int lngVal, int codeLength) {
   List<String> code = List<String>.filled(maxDigitCount + 1, '');
   code[separatorPosition] = separator;
 

--- a/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
@@ -200,29 +200,37 @@ public final class OpenLocationCode {
     this.code = encodeIntegers(integers[0], integers[1], codeLength);
   }
 
-  private static String encodeIntegers(long latVal, long lngVal, int codeLength) {
+  /**
+   * Encode a location specified with integer values and return the code.
+   *
+   * @param lat The latitude as a positive integer.
+   * @param lng The longitude as a positive integer.
+   * @param codeLength The requested number of digits.
+   * @return The OLC for the location.
+   */
+  private static String encodeIntegers(long lat, long lng, int codeLength) {
     // Store the code - we build it in reverse and reorder it afterwards.
     StringBuilder revCodeBuilder = new StringBuilder();
     // Compute the grid part of the code if necessary.
     if (codeLength > PAIR_CODE_LENGTH) {
       for (int i = 0; i < GRID_CODE_LENGTH; i++) {
-        long latDigit = latVal % GRID_ROWS;
-        long lngDigit = lngVal % GRID_COLUMNS;
+        long latDigit = lat % GRID_ROWS;
+        long lngDigit = lng % GRID_COLUMNS;
         int ndx = (int) (latDigit * GRID_COLUMNS + lngDigit);
         revCodeBuilder.append(CODE_ALPHABET.charAt(ndx));
-        latVal /= GRID_ROWS;
-        lngVal /= GRID_COLUMNS;
+        lat /= GRID_ROWS;
+        lng /= GRID_COLUMNS;
       }
     } else {
-      latVal = (long) (latVal / Math.pow(GRID_ROWS, GRID_CODE_LENGTH));
-      lngVal = (long) (lngVal / Math.pow(GRID_COLUMNS, GRID_CODE_LENGTH));
+      lat = (long) (lat / Math.pow(GRID_ROWS, GRID_CODE_LENGTH));
+      lng = (long) (lng / Math.pow(GRID_COLUMNS, GRID_CODE_LENGTH));
     }
     // Compute the pair section of the code.
     for (int i = 0; i < PAIR_CODE_LENGTH / 2; i++) {
-      revCodeBuilder.append(CODE_ALPHABET.charAt((int) (lngVal % ENCODING_BASE)));
-      revCodeBuilder.append(CODE_ALPHABET.charAt((int) (latVal % ENCODING_BASE)));
-      latVal /= ENCODING_BASE;
-      lngVal /= ENCODING_BASE;
+      revCodeBuilder.append(CODE_ALPHABET.charAt((int) (lng % ENCODING_BASE)));
+      revCodeBuilder.append(CODE_ALPHABET.charAt((int) (lat % ENCODING_BASE)));
+      lat /= ENCODING_BASE;
+      lng /= ENCODING_BASE;
       // If we are at the separator position, add the separator.
       if (i == 0) {
         revCodeBuilder.append(SEPARATOR);
@@ -647,6 +655,14 @@ public final class OpenLocationCode {
 
   // Private static methods.
 
+  /**
+   * Convert latitude and longitude in degrees into the integer values needed for reliable encoding.
+   * (To avoid floating point precision errors.)
+   *
+   * @param latitude The latitude in decimal degrees.
+   * @param longitude The longitude in decimal degrees.
+   * @return A list of [latitude, longitude] in clipped, normalised integer values.
+   */
   private static long[] degreesToIntegers(double latitude, double longitude) {
     long lat = (long) roundAwayFromZero(latitude * LAT_INTEGER_MULTIPLIER);
     long lng = (long) roundAwayFromZero(longitude * LNG_INTEGER_MULTIPLIER);
@@ -666,7 +682,7 @@ public final class OpenLocationCode {
     } else if (lng >= 2 * LONGITUDE_MAX * LNG_INTEGER_MULTIPLIER) {
       lng = lng % (2 * LONGITUDE_MAX * LNG_INTEGER_MULTIPLIER);
     }
-    return new long[]{lat, lng};
+    return new long[] {lat, lng};
   }
 
   /**

--- a/js/closure/openlocationcode.js
+++ b/js/closure/openlocationcode.js
@@ -413,7 +413,7 @@ function _locationToIntegers(latitude, longitude) {
   }
   return [latVal, lngVal];
 }
-exports._latitudeToInteger = _latitudeToInteger;
+exports._locationToIntegers = _locationToIntegers;
 
 /**
   Encode a location that uses integer values into an Open Location Code.

--- a/plpgsql/tests_script_l.sql
+++ b/plpgsql/tests_script_l.sql
@@ -1,5 +1,14 @@
 --Test script for openlocationcode functions
 
+
+--###############################################################
+--pluscode_latitudeToInteger
+select pluscode_latitudeToInteger(149.18);
+ -- pluscode_latitudeToInteger
+-----------------
+                    -- 4499999999
+-- (1 row)
+
 --###############################################################
 --pluscode_cliplatitude
 select pluscode_cliplatitude(149.18);

--- a/python/openlocationcode/openlocationcode.py
+++ b/python/openlocationcode/openlocationcode.py
@@ -226,6 +226,36 @@ def isFull(code):
         return False
     return True
 
+def locationToIntegers(latitude, longitude):
+    """
+    Convert location in degrees into the integer representations.
+
+    This function is exposed for testing purposes and should not be called
+    directly.
+
+    Args:
+      latitude: Latitude in degrees.
+      longitude: Longitude in degrees.
+    Return:
+      A tuple of the [latitude, longitude] values as integers.
+    """
+    latVal = int(round(latitude * FINAL_LAT_PRECISION_))
+    latVal += LATITUDE_MAX_ * FINAL_LAT_PRECISION_
+    if latVal < 0:
+        latVal = 0
+    elif latVal >= 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_:
+        latVal = 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_ - 1
+
+    lngVal = int(round(longitude * FINAL_LNG_PRECISION_))
+    lngVal += LONGITUDE_MAX_ * FINAL_LNG_PRECISION_
+    if lngVal < 0:
+        # Python's % operator differs from other languages in that it returns
+        # the same sign as the divisor. This means we don't need to add the
+        # range to the result.
+        lngVal = lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_)
+    elif lngVal >= 2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_:
+        lngVal = lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_)
+    return (latVal, lngVal)
 
 def encode(latitude, longitude, codeLength=PAIR_CODE_LENGTH_):
     """
@@ -249,32 +279,16 @@ def encode(latitude, longitude, codeLength=PAIR_CODE_LENGTH_):
         raise ValueError('Invalid Open Location Code length - ' +
                          str(codeLength))
     codeLength = min(codeLength, MAX_DIGIT_COUNT_)
+    (latInt, lngInt) = locationToIntegers(latitude, longitude)
+    return encodeIntegers(latInt, lngInt, codeLength)
 
-    # Compute the code.
-    # This approach converts latitude and longitude to integers. This allows us
-    # to use only integer operations, so avoiding any accumulation of floating
-    # point representation errors.
+def encodeIntegers(latVal, lngVal, codeLength):
+    """
+    Encode a location, as two integer values, into a code.
 
-    # Multiply values by their precision and convert to positive.
-    # Force to integers so the division operations will have integer results.
-    # Note: Python requires rounding before truncating to ensure precision!
-    latVal = int(round(latitude * FINAL_LAT_PRECISION_))
-    latVal += LATITUDE_MAX_ * FINAL_LAT_PRECISION_
-    if latVal < 0:
-        latVal = 0
-    elif latVal >= 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_:
-        latVal = 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_ - 1
-
-    lngVal = int(round(longitude * FINAL_LNG_PRECISION_))
-    lngVal += LONGITUDE_MAX_ * FINAL_LNG_PRECISION_
-    if lngVal < 0:
-        # Python's % operator differs from other languages in that it returns
-        # the same sign as the divisor. This means we don't need to add the
-        # range to the result.
-        lngVal = lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_)
-    elif lngVal >= 2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_:
-        lngVal = lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_)
-
+    This function is exposed for testing purposes and should not be called
+    directly.
+    """
     # Initialise the code string.
     code = ''
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,4 +6,7 @@ mod interface;
 mod private;
 
 pub use codearea::CodeArea;
-pub use interface::{decode, encode, encode_integers, is_full, is_short, is_valid, point_to_integers, recover_nearest, shorten};
+pub use interface::{
+    decode, encode, encode_integers, is_full, is_short, is_valid, point_to_integers,
+    recover_nearest, shorten,
+};

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,4 +6,4 @@ mod interface;
 mod private;
 
 pub use codearea::CodeArea;
-pub use interface::{decode, encode, is_full, is_short, is_valid, recover_nearest, shorten};
+pub use interface::{decode, encode, encode_integers, is_full, is_short, is_valid, point_to_integers, recover_nearest, shorten};


### PR DESCRIPTION
Fixes #672 

This is because we cannot rely on "correct" conversions from the floating point coordinates in degrees to integer values. So we need to split the encode methods, and test using integer values against an integer encoding method.