### PR TITLE
cpp: use floor for integer conversion

### DIFF
--- a/c/openlocationcode_test.cc
+++ b/c/openlocationcode_test.cc
@@ -122,7 +122,7 @@ std::vector<EncodingTestData> GetEncodingDataFromCsv() {
   return data_results;
 }
 
-// TolerantTestParams runs a test with the
+// TolerantTestParams runs a test with a permitted failure rate.
 struct TolerantTestParams {
   double allowed_failure_rate;
   std::vector<EncodingTestData> test_data;

--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -49,7 +49,7 @@ const int kPositionLUT['X' - 'C' + 1] = {8,  -1, -1, 9,  10, 11, -1, 12,
                                          -1, -1, -1, 17, 18, 19};
 
 int64_t latitudeToInteger(double latitude) {
-  int64_t lat = round(latitude * kGridLatPrecisionInverse);
+  int64_t lat = floor(latitude * kGridLatPrecisionInverse);
   lat += kLatitudeMaxDegrees * kGridLatPrecisionInverse;
   if (lat < 0) {
     lat = 0;
@@ -60,7 +60,7 @@ int64_t latitudeToInteger(double latitude) {
 }
 
 int64_t longitudeToInteger(double longitude) {
-  int64_t lng = round(longitude * kGridLngPrecisionInverse);
+  int64_t lng = floor(longitude * kGridLngPrecisionInverse);
   lng += kLongitudeMaxDegrees * kGridLngPrecisionInverse;
   if (lng <= 0) {
     lng = lng % (2 * kLongitudeMaxDegrees * kGridLngPrecisionInverse) +


### PR DESCRIPTION
See issues #674  and #717.

This corrects the implementation to use floor when converting from degrees to the integer values, and adds tests for the conversion of degrees to integer, encoding from integers, and adds tolerance to the degrees encoding (due to floating point precision).