### PR TITLE
go: use floor for conversion, use integer tests

### DIFF
--- a/go/encode.go
+++ b/go/encode.go
@@ -42,13 +42,13 @@ func Encode(lat, lng float64, codeLen int) string {
 	// This allows us to use only integer operations, so avoiding any accumulation of floating point representation errors.
 	latVal := latitudeAsInteger(lat)
 	lngVal := longitudeAsInteger(lng)
-	// Clip the code length to legal values.
-	codeLen = clipCodeLen(codeLen)
 	// Call the integer based encoding method.
 	return integerEncode(latVal, lngVal, codeLen)
 }
 
 func integerEncode(latVal, lngVal int64, codeLen int) string {
+	// Clip the code length to legal values.
+	codeLen = clipCodeLen(codeLen)
 	// Use a char array so we can build it up from the end digits, without having to keep reallocating strings.
 	// Prime it with padding and separator.
 	var code []byte = []byte("00000000+0012345")

--- a/go/olc.go
+++ b/go/olc.go
@@ -232,7 +232,7 @@ func normalizeLng(value float64) float64 {
 // latitudeAsInteger converts a latitude in degrees into the integer representation.
 // It will be clipped into the degree range -90<=x<90 (actually 0-180*2.5e7-1).
 func latitudeAsInteger(latDegrees float64) int64 {
-	latVal := int64(math.Round(latDegrees * finalLatPrecision))
+	latVal := int64(math.Floor(latDegrees * finalLatPrecision))
 	latVal += latMax * finalLatPrecision
 	if latVal < 0 {
 		latVal = 0
@@ -245,7 +245,7 @@ func latitudeAsInteger(latDegrees float64) int64 {
 // longitudeAsInteger converts a longitude in degrees into the integer representation.
 // It will be normalised into the degree range -180<=x<180 (actually 0-360*8.192e6).
 func longitudeAsInteger(lngDegrees float64) int64 {
-	lngVal := int64(math.Round(lngDegrees * finalLngPrecision))
+	lngVal := int64(math.Floor(lngDegrees * finalLngPrecision))
 	lngVal += lngMax * finalLngPrecision
 	if lngVal <= 0 {
 		lngVal = lngVal%(2*lngMax*finalLngPrecision) + 2*lngMax*finalLngPrecision


### PR DESCRIPTION
See issues https://github.com/google/open-location-code/issues/674 and https://github.com/google/open-location-code/issues/717.

This corrects the implementation to use floor when converting from degrees to the integer values, and adds tests for the conversion of degrees to integer, encoding from integers, and adds tolerance to the degrees encoding (due to floating point precision).