### PR TITLE
java: use floor for conversion, add integer tests

### DIFF
--- a/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
@@ -188,13 +188,6 @@ public final class OpenLocationCode {
    * @throws IllegalArgumentException if the code length is not valid.
    */
   public OpenLocationCode(double latitude, double longitude, int codeLength) {
-    // Limit the maximum number of digits in the code.
-    codeLength = Math.min(codeLength, MAX_DIGIT_COUNT);
-    // Check that the code length requested is valid.
-    if (codeLength < PAIR_CODE_LENGTH && codeLength % 2 == 1 || codeLength < MIN_DIGIT_COUNT) {
-      throw new IllegalArgumentException("Illegal code length " + codeLength);
-    }
-
     // Compute the code.
     long[] integers = degreesToIntegers(latitude, longitude);
     this.code = encodeIntegers(integers[0], integers[1], codeLength);
@@ -207,8 +200,16 @@ public final class OpenLocationCode {
    * @param lng The longitude as a positive integer.
    * @param codeLength The requested number of digits.
    * @return The OLC for the location.
+   * @throws IllegalArgumentException if the code length is not valid.
    */
-  private static String encodeIntegers(long lat, long lng, int codeLength) {
+   static String encodeIntegers(long lat, long lng, int codeLength) {
+    // Limit the maximum number of digits in the code.
+    codeLength = Math.min(codeLength, MAX_DIGIT_COUNT);
+    // Check that the code length requested is valid.
+    if (codeLength < PAIR_CODE_LENGTH && codeLength % 2 == 1 || codeLength < MIN_DIGIT_COUNT) {
+      throw new IllegalArgumentException("Illegal code length " + codeLength);
+    }
+
     // Store the code - we build it in reverse and reorder it afterwards.
     StringBuilder revCodeBuilder = new StringBuilder();
     // Compute the grid part of the code if necessary.
@@ -663,9 +664,9 @@ public final class OpenLocationCode {
    * @param longitude The longitude in decimal degrees.
    * @return A list of [latitude, longitude] in clipped, normalised integer values.
    */
-  private static long[] degreesToIntegers(double latitude, double longitude) {
-    long lat = (long) roundAwayFromZero(latitude * LAT_INTEGER_MULTIPLIER);
-    long lng = (long) roundAwayFromZero(longitude * LNG_INTEGER_MULTIPLIER);
+  static long[] degreesToIntegers(double latitude, double longitude) {
+    long lat = (long) Math.floor(latitude * LAT_INTEGER_MULTIPLIER);
+    long lng = (long) Math.floor(longitude * LNG_INTEGER_MULTIPLIER);
 
     // Clip and normalise values.
     lat += LATITUDE_MAX * LAT_INTEGER_MULTIPLIER;
@@ -683,20 +684,6 @@ public final class OpenLocationCode {
       lng = lng % (2 * LONGITUDE_MAX * LNG_INTEGER_MULTIPLIER);
     }
     return new long[] {lat, lng};
-  }
-
-  /**
-   * Round numbers like C does. This implements rounding away from zero (see
-   * https://en.wikipedia.org/wiki/Rounding).
-   *
-   * @param num A number to round.
-   * @return The rounded value.
-   */
-  private static Long roundAwayFromZero(double num) {
-    if (num >= 0) {
-      return Math.round(num);
-    }
-    return -1 * Math.round(Math.abs(num));
   }
 
   private static double clipLatitude(double latitude) {

--- a/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
+++ b/java/src/main/java/com/google/openlocationcode/OpenLocationCode.java
@@ -202,7 +202,7 @@ public final class OpenLocationCode {
    * @return The OLC for the location.
    * @throws IllegalArgumentException if the code length is not valid.
    */
-   static String encodeIntegers(long lat, long lng, int codeLength) {
+  static String encodeIntegers(long lat, long lng, int codeLength) {
     // Limit the maximum number of digits in the code.
     codeLength = Math.min(codeLength, MAX_DIGIT_COUNT);
     // Check that the code length requested is valid.

--- a/java/src/test/java/com/google/openlocationcode/EncodingTest.java
+++ b/java/src/test/java/com/google/openlocationcode/EncodingTest.java
@@ -31,7 +31,7 @@ public class EncodingTest {
 
     public TestData(String line) {
       String[] parts = line.split(",");
-      if (parts.length != 4) {
+      if (parts.length != 6) {
         throw new IllegalArgumentException("Wrong format of testing data.");
       }
       this.latitudeDegrees = Double.parseDouble(parts[0]);

--- a/java/src/test/java/com/google/openlocationcode/EncodingTest.java
+++ b/java/src/test/java/com/google/openlocationcode/EncodingTest.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/java/src/test/java/com/google/openlocationcode/EncodingTest.java
+++ b/java/src/test/java/com/google/openlocationcode/EncodingTest.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,34 +63,49 @@ public class EncodingTest {
     double allowedErrorRate = 0.05;
     int failedEncodings = 0;
     for (TestData testData : testDataList) {
-      String got = OpenLocationCode.encode(testData.latitudeDegrees, testData.longitudeDegrees, testData.length);
+      String got =
+          OpenLocationCode.encode(
+              testData.latitudeDegrees, testData.longitudeDegrees, testData.length);
       if (got != testData.code) {
         failedEncodings++;
         System.out.printf(
-          "ENCODING DIFFERENCE: encode(%f,%f,%d) got %s, want %s\n",
-          testData.latitudeDegrees, testData.longitudeDegrees, testData.length, got, testData.code);
+            "ENCODING DIFFERENCE: encode(%f,%f,%d) got %s, want %s\n",
+            testData.latitudeDegrees,
+            testData.longitudeDegrees,
+            testData.length,
+            got,
+            testData.code);
       }
-      Assert.assertTrue(
-          String.format(
-              "Too many encoding errors (actual rate %f, allowed rate %f), see ENCODING DIFFERENCE lines",
-              failedEncodings / testDataList.size(), allowedErrorRate),
-          failedEncodings / testDataList.size() <= allowedErrorRate);
     }
+    double gotRate = (double) failedEncodings / (double) testDataList.size();
+    Assert.assertTrue(
+        String.format(
+            "Too many encoding errors (actual rate %f, allowed rate %f), see ENCODING DIFFERENCE"
+                + " lines",
+            gotRate, allowedErrorRate),
+        gotRate <= allowedErrorRate);
   }
 
   @Test
   public void testDegreesToIntegers() {
     for (TestData testData : testDataList) {
-      long[] got = OpenLocationCode.degreesToIntegers(testData.latitudeDegrees, testData.latitudeDegrees);
+      long[] got =
+          OpenLocationCode.degreesToIntegers(testData.latitudeDegrees, testData.latitudeDegrees);
       Assert.assertTrue(
           String.format(
               "degreesToIntegers(%f, %f) returned latitude %d, expected %d",
-              testData.latitudeDegrees, testData.longitudeDegrees, got[0], testData.latitudeInteger),
+              testData.latitudeDegrees,
+              testData.longitudeDegrees,
+              got[0],
+              testData.latitudeInteger),
           got[0] == testData.latitudeInteger || got[0] == testData.latitudeInteger - 1);
       Assert.assertTrue(
           String.format(
               "degreesToIntegers(%f, %f) returned longitude %d, expected %d",
-              testData.latitudeDegrees, testData.longitudeDegrees, got[1], testData.longitudeInteger),
+              testData.latitudeDegrees,
+              testData.longitudeDegrees,
+              got[1],
+              testData.longitudeInteger),
           got[1] == testData.longitudeInteger || got[1] == testData.longitudeInteger - 1);
     }
   }
@@ -104,7 +118,8 @@ public class EncodingTest {
               "Latitude %d, longitude %d and length %d were wrongly encoded.",
               testData.latitudeInteger, testData.longitudeInteger, testData.length),
           testData.code,
-          OpenLocationCode.encodeIntegers(testData.latitudeInteger, testData.longitudeInteger, testData.length));
+          OpenLocationCode.encodeIntegers(
+              testData.latitudeInteger, testData.longitudeInteger, testData.length));
     }
   }
 }

--- a/java/src/test/java/com/google/openlocationcode/EncodingTest.java
+++ b/java/src/test/java/com/google/openlocationcode/EncodingTest.java
@@ -73,7 +73,8 @@ public class EncodingTest {
       }
       Assert.assertTrue(
           String.format(
-              "Too many encoding errors (actual rate %f, allowed rate %f), see ENCODING DIFFERENCE lines"),
+              "Too many encoding errors (actual rate %f, allowed rate %f), see ENCODING DIFFERENCE lines",
+              failedEncodings / testDataList.size(), allowedErrorRate),
           failedEncodings / testDataList.size() <= allowedErrorRate);
     }
   }

--- a/java/src/test/java/com/google/openlocationcode/EncodingTest.java
+++ b/java/src/test/java/com/google/openlocationcode/EncodingTest.java
@@ -66,7 +66,7 @@ public class EncodingTest {
       String got =
           OpenLocationCode.encode(
               testData.latitudeDegrees, testData.longitudeDegrees, testData.length);
-      if (got != testData.code) {
+      if (!testData.code.equals(got)) {
         failedEncodings++;
         System.out.printf(
             "ENCODING DIFFERENCE: encode(%f,%f,%d) got %s, want %s\n",
@@ -90,7 +90,7 @@ public class EncodingTest {
   public void testDegreesToIntegers() {
     for (TestData testData : testDataList) {
       long[] got =
-          OpenLocationCode.degreesToIntegers(testData.latitudeDegrees, testData.latitudeDegrees);
+          OpenLocationCode.degreesToIntegers(testData.latitudeDegrees, testData.longitudeDegrees);
       Assert.assertTrue(
           String.format(
               "degreesToIntegers(%f, %f) returned latitude %d, expected %d",

--- a/java/src/test/java/com/google/openlocationcode/EncodingTest.java
+++ b/java/src/test/java/com/google/openlocationcode/EncodingTest.java
@@ -74,7 +74,7 @@ public class EncodingTest {
       Assert.assertTrue(
           String.format(
               "Too many encoding errors (actual rate %f, allowed rate %f), see ENCODING DIFFERENCE lines"),
-          failedEncodings / testDataList.size() <= allowedErrorRate,);
+          failedEncodings / testDataList.size() <= allowedErrorRate);
     }
   }
 
@@ -92,7 +92,6 @@ public class EncodingTest {
               "degreesToIntegers(%f, %f) returned longitude %d, expected %d",
               testData.latitudeDegrees, testData.longitudeDegrees, got[1], testData.longitudeInteger),
           got[1] == testData.longitudeInteger || got[1] == testData.longitudeInteger - 1);
-    }
     }
   }
 


### PR DESCRIPTION
See issues https://github.com/google/open-location-code/issues/674 and https://github.com/google/open-location-code/issues/717.

This corrects the implementation to use floor when converting from degrees to the integer values, and adds tests for the conversion of degrees to integer, encoding from integers, and adds tolerance to the degrees encoding (due to floating point precision).