### PR TITLE
js/closure: use floor for conversion, add integer tests

### DIFF
--- a/js/closure/openlocationcode.js
+++ b/js/closure/openlocationcode.js
@@ -384,14 +384,14 @@ exports.encode = encode;
  * @return {Array<number>} A tuple of the latitude integer and longitude integer.
  */
 function _locationToIntegers(latitude, longitude) {
-  var latVal = roundAwayFromZero(latitude * FINAL_LAT_PRECISION);
+  var latVal = Math.floor(latitude * FINAL_LAT_PRECISION);
   latVal += LATITUDE_MAX * FINAL_LAT_PRECISION;
   if (latVal < 0) {
     latVal = 0;
   } else if (latVal >= 2 * LATITUDE_MAX * FINAL_LAT_PRECISION) {
     latVal = 2 * LATITUDE_MAX * FINAL_LAT_PRECISION - 1;
   }
-  var lngVal = roundAwayFromZero(longitude * FINAL_LNG_PRECISION);
+  var lngVal = Math.floor(longitude * FINAL_LNG_PRECISION);
   lngVal += LONGITUDE_MAX * FINAL_LNG_PRECISION;
   if (lngVal < 0) {
     lngVal =
@@ -693,20 +693,6 @@ function shorten(code, latitude, longitude) {
   return code;
 }
 exports.shorten = shorten;
-
-/**
- * Round numbers like C does. This implements rounding away from zero (see
- * https://en.wikipedia.org/wiki/Rounding).
- *
- * @param {number} num A number to round.
- * @return {number} The rounded value usn
- */
-function roundAwayFromZero(num) {
-  if (num >= 0) {
-    return Math.round(num);
-  }
-  return -1 * Math.round(Math.abs(num));
-}
 
 /**
   Clip a latitude into the range -90 to 90.

--- a/js/closure/openlocationcode.js
+++ b/js/closure/openlocationcode.js
@@ -362,17 +362,6 @@ exports.isFull = isFull;
       specified.
  */
 function encode(latitude, longitude, codeLength) {
-  if (typeof codeLength == 'undefined') {
-    codeLength = PAIR_CODE_LENGTH;
-  }
-  if (
-    codeLength < MIN_CODE_LEN ||
-    (codeLength < PAIR_CODE_LENGTH && codeLength % 2 == 1)
-  ) {
-    throw new Error('IllegalArgumentException: Invalid Plus Code length');
-  }
-  codeLength = Math.min(codeLength, MAX_CODE_LEN);
-
   const locationIntegers = _locationToIntegers(latitude, longitude);
 
   return _encodeIntegers(locationIntegers[0], locationIntegers[1], codeLength);
@@ -428,6 +417,17 @@ exports._locationToIntegers = _locationToIntegers;
       specified.
  */
 function _encodeIntegers(latInt, lngInt, codeLength) {
+  if (typeof codeLength == 'undefined') {
+    codeLength = PAIR_CODE_LENGTH;
+  }
+  if (
+    codeLength < MIN_CODE_LEN ||
+    (codeLength < PAIR_CODE_LENGTH && codeLength % 2 == 1)
+  ) {
+    throw new Error('IllegalArgumentException: Invalid Plus Code length');
+  }
+  codeLength = Math.min(codeLength, MAX_CODE_LEN);
+
   // Javascript strings are immutable and it doesn't have a native
   // StringBuilder, so we'll use an array.
   const code = new Array(MAX_CODE_LEN + 1);

--- a/js/closure/openlocationcode_test.js
+++ b/js/closure/openlocationcode_test.js
@@ -79,8 +79,8 @@ testSuite({
         const fields = lines[i].split(',');
         const latDegrees = parseFloat(fields[0]);
         const lngDegrees = parseFloat(fields[1]);
-        const length = parseInt(fields[2], 10);
-        const code = fields[3];
+        const length = parseInt(fields[4], 10);
+        const code = fields[5];
 
         const got = OpenLocationCode.encode(latDegrees, lngDegrees, length);
         // Did we get the same code?

--- a/js/closure/openlocationcode_test.js
+++ b/js/closure/openlocationcode_test.js
@@ -108,8 +108,8 @@ testSuite({
         const fields = lines[i].split(',');
         const latDegrees = parseFloat(fields[0]);
         const lngDegrees = parseFloat(fields[1]);
-        const latIntegers = parseInt(fields[2]);
-        const lngIntegers = parseInt(fields[3]);
+        const latIntegers = parseInt(fields[2], 10);
+        const lngIntegers = parseInt(fields[3], 10);
 
         const got = OpenLocationCode._locationToIntegers(
           latDegrees,
@@ -137,8 +137,8 @@ testSuite({
       const lines = xhrIo_.getResponseText().match(/^[^#].+/gm);
       for (var i = 0; i < lines.length; i++) {
         const fields = lines[i].split(',');
-        const latIntegers = parseInt(fields[2]);
-        const lngIntegers = parseInt(fields[3]);
+        const latIntegers = parseInt(fields[2], 10);
+        const lngIntegers = parseInt(fields[3], 10);
         const length = parseInt(fields[2], 10);
         const code = fields[3];
 
@@ -149,7 +149,8 @@ testSuite({
         );
         // Did we get the same code?
         assertEquals(
-          'testEncodeIntegers: expected code ' + code + ', got ' + got
+          'testEncodeIntegers: expected code ' + code + ', got ' + got,
+          code, got
         );
         asyncTestCase.continueTesting();
       }

--- a/js/closure/openlocationcode_test.js
+++ b/js/closure/openlocationcode_test.js
@@ -85,16 +85,17 @@ testSuite({
         const got = OpenLocationCode.encode(latDegrees, lngDegrees, length);
         // Did we get the same code?
         if (code != got) {
-          console.log(
+          console.warn(
             'ENCODING DIFFERENCE: Expected code ' + code +', got ' + got
           );
           errors++;
         }
         asyncTestCase.continueTesting();
       }
+      console.info('testEncodeDegrees error rate is ' + (errors / lines.length));
       assertTrue(
         'testEncodeDegrees: too many errors ' + errors / lines.length,
-        errors / lines.length < allowedErrorRate
+        (errors / lines.length) < allowedErrorRate
       );
     });
     asyncTestCase.waitForAsync('Waiting for xhr to respond');
@@ -118,11 +119,11 @@ testSuite({
         // Due to floating point precision limitations, we may get values 1 less
         // than expected.
         assertTrue(
-          'testEncodeIntegers: expected latitude ' + latIntegers + ', got ' + got[0],
+          'testLocationToIntegers: expected latitude ' + latIntegers + ', got ' + got[0],
           got[0] == latIntegers || got[0] == latIntegers - 1
         );
         assertTrue(
-          'testEncodeIntegers: expected longitude ' + lngIntegers + ', got ' + got[1],
+          'testLocationToIntegers: expected longitude ' + lngIntegers + ', got ' + got[1],
           got[1] == lngIntegers || got[1] == lngIntegers - 1
         );
         asyncTestCase.continueTesting();
@@ -139,8 +140,8 @@ testSuite({
         const fields = lines[i].split(',');
         const latIntegers = parseInt(fields[2], 10);
         const lngIntegers = parseInt(fields[3], 10);
-        const length = parseInt(fields[2], 10);
-        const code = fields[3];
+        const length = parseInt(fields[4], 10);
+        const code = fields[5];
 
         const got = OpenLocationCode._encodeIntegers(
           latIntegers,

--- a/js/closure/openlocationcode_test.js
+++ b/js/closure/openlocationcode_test.js
@@ -67,7 +67,7 @@ testSuite({
     asyncTestCase.waitForAsync('Waiting for xhr to respond');
     xhrIo_.send(DECODING_TEST_FILE, 'GET');
   },
-  testEncodeDegrees: function () {
+  testEncodeDegrees: function() {
     const xhrIo_ = new XhrIo();
     xhrIo_.listenOnce(EventType.COMPLETE, () => {
       // Allow a 5% error rate encoding from degree coordinates (because of floating
@@ -86,7 +86,7 @@ testSuite({
         // Did we get the same code?
         if (code != got) {
           console.warn(
-            'ENCODING DIFFERENCE: Expected code ' + code +', got ' + got
+              'ENCODING DIFFERENCE: Expected code ' + code +', got ' + got
           );
           errors++;
         }
@@ -94,14 +94,14 @@ testSuite({
       }
       console.info('testEncodeDegrees error rate is ' + (errors / lines.length));
       assertTrue(
-        'testEncodeDegrees: too many errors ' + errors / lines.length,
-        (errors / lines.length) < allowedErrorRate
+          'testEncodeDegrees: too many errors ' + errors / lines.length,
+          (errors / lines.length) < allowedErrorRate
       );
     });
     asyncTestCase.waitForAsync('Waiting for xhr to respond');
     xhrIo_.send(ENCODING_TEST_FILE, 'GET');
   },
-  testLocationToIntegers: function () {
+  testLocationToIntegers: function() {
     const xhrIo_ = new XhrIo();
     xhrIo_.listenOnce(EventType.COMPLETE, () => {
       const lines = xhrIo_.getResponseText().match(/^[^#].+/gm);
@@ -113,18 +113,18 @@ testSuite({
         const lngIntegers = parseInt(fields[3], 10);
 
         const got = OpenLocationCode._locationToIntegers(
-          latDegrees,
-          lngDegrees
+            latDegrees,
+            lngDegrees
         );
         // Due to floating point precision limitations, we may get values 1 less
         // than expected.
         assertTrue(
-          'testLocationToIntegers: expected latitude ' + latIntegers + ', got ' + got[0],
-          got[0] == latIntegers || got[0] == latIntegers - 1
+            'testLocationToIntegers: expected latitude ' + latIntegers + ', got ' + got[0],
+            got[0] == latIntegers || got[0] == latIntegers - 1
         );
         assertTrue(
-          'testLocationToIntegers: expected longitude ' + lngIntegers + ', got ' + got[1],
-          got[1] == lngIntegers || got[1] == lngIntegers - 1
+            'testLocationToIntegers: expected longitude ' + lngIntegers + ', got ' + got[1],
+            got[1] == lngIntegers || got[1] == lngIntegers - 1
         );
         asyncTestCase.continueTesting();
       }
@@ -132,7 +132,7 @@ testSuite({
     asyncTestCase.waitForAsync('Waiting for xhr to respond');
     xhrIo_.send(ENCODING_TEST_FILE, 'GET');
   },
-  testEncodeIntegers: function () {
+  testEncodeIntegers: function() {
     const xhrIo_ = new XhrIo();
     xhrIo_.listenOnce(EventType.COMPLETE, () => {
       const lines = xhrIo_.getResponseText().match(/^[^#].+/gm);
@@ -144,14 +144,14 @@ testSuite({
         const code = fields[5];
 
         const got = OpenLocationCode._encodeIntegers(
-          latIntegers,
-          lngIntegers,
-          length
+            latIntegers,
+            lngIntegers,
+            length
         );
         // Did we get the same code?
         assertEquals(
-          'testEncodeIntegers: expected code ' + code + ', got ' + got,
-          code, got
+            'testEncodeIntegers: expected code ' + code + ', got ' + got,
+            code, got
         );
         asyncTestCase.continueTesting();
       }

--- a/js/closure/openlocationcode_test.js
+++ b/js/closure/openlocationcode_test.js
@@ -67,21 +67,90 @@ testSuite({
     asyncTestCase.waitForAsync('Waiting for xhr to respond');
     xhrIo_.send(DECODING_TEST_FILE, 'GET');
   },
-  testEncode: function() {
+  testEncodeDegrees: function () {
+    const xhrIo_ = new XhrIo();
+    xhrIo_.listenOnce(EventType.COMPLETE, () => {
+      // Allow a 5% error rate encoding from degree coordinates (because of floating
+      // point precision).
+      const allowedErrorRate = 0.05;
+      var errors = 0;
+      const lines = xhrIo_.getResponseText().match(/^[^#].+/gm);
+      for (var i = 0; i < lines.length; i++) {
+        const fields = lines[i].split(',');
+        const latDegrees = parseFloat(fields[0]);
+        const lngDegrees = parseFloat(fields[1]);
+        const length = parseInt(fields[2], 10);
+        const code = fields[3];
+
+        const got = OpenLocationCode.encode(latDegrees, lngDegrees, length);
+        // Did we get the same code?
+        if (code != got) {
+          console.log(
+            'ENCODING DIFFERENCE: Expected code ' + code +', got ' + got
+          );
+          errors++;
+        }
+        asyncTestCase.continueTesting();
+      }
+      assertTrue(
+        'testEncodeDegrees: too many errors ' + errors / lines.length,
+        errors / lines.length < allowedErrorRate
+      );
+    });
+    asyncTestCase.waitForAsync('Waiting for xhr to respond');
+    xhrIo_.send(ENCODING_TEST_FILE, 'GET');
+  },
+  testLocationToIntegers: function () {
     const xhrIo_ = new XhrIo();
     xhrIo_.listenOnce(EventType.COMPLETE, () => {
       const lines = xhrIo_.getResponseText().match(/^[^#].+/gm);
       for (var i = 0; i < lines.length; i++) {
         const fields = lines[i].split(',');
-        const lat = parseFloat(fields[0]);
-        const lng = parseFloat(fields[1]);
+        const latDegrees = parseFloat(fields[0]);
+        const lngDegrees = parseFloat(fields[1]);
+        const latIntegers = parseInt(fields[2]);
+        const lngIntegers = parseInt(fields[3]);
+
+        const got = OpenLocationCode._locationToIntegers(
+          latDegrees,
+          lngDegrees
+        );
+        // Due to floating point precision limitations, we may get values 1 less
+        // than expected.
+        assertTrue(
+          'testEncodeIntegers: expected latitude ' + latIntegers + ', got ' + got[0],
+          got[0] == latIntegers || got[0] == latIntegers - 1
+        );
+        assertTrue(
+          'testEncodeIntegers: expected longitude ' + lngIntegers + ', got ' + got[1],
+          got[1] == lngIntegers || got[1] == lngIntegers - 1
+        );
+        asyncTestCase.continueTesting();
+      }
+    });
+    asyncTestCase.waitForAsync('Waiting for xhr to respond');
+    xhrIo_.send(ENCODING_TEST_FILE, 'GET');
+  },
+  testEncodeIntegers: function () {
+    const xhrIo_ = new XhrIo();
+    xhrIo_.listenOnce(EventType.COMPLETE, () => {
+      const lines = xhrIo_.getResponseText().match(/^[^#].+/gm);
+      for (var i = 0; i < lines.length; i++) {
+        const fields = lines[i].split(',');
+        const latIntegers = parseInt(fields[2]);
+        const lngIntegers = parseInt(fields[3]);
         const length = parseInt(fields[2], 10);
         const code = fields[3];
 
-        const gotCode = OpenLocationCode.encode(lat, lng, length);
+        const got = OpenLocationCode._encodeIntegers(
+          latIntegers,
+          lngIntegers,
+          length
+        );
         // Did we get the same code?
-        assertEquals('testEncode ' + 1, code, gotCode);
-
+        assertEquals(
+          'testEncodeIntegers: expected code ' + code + ', got ' + got
+        );
         asyncTestCase.continueTesting();
       }
     });


### PR DESCRIPTION
See issues https://github.com/google/open-location-code/issues/674 and https://github.com/google/open-location-code/issues/717.

This corrects the implementation to use floor when converting from degrees to the integer values, and adds tests for the conversion of degrees to integer, encoding from integers, and adds tolerance to the degrees encoding (due to floating point precision).