### PR TITLE
python: use floor for conversion, add integer tests

### DIFF
--- a/python/openlocationcode/openlocationcode.py
+++ b/python/openlocationcode/openlocationcode.py
@@ -226,6 +226,7 @@ def isFull(code):
         return False
     return True
 
+
 def locationToIntegers(latitude, longitude):
     """
     Convert location in degrees into the integer representations.
@@ -239,14 +240,14 @@ def locationToIntegers(latitude, longitude):
     Return:
       A tuple of the [latitude, longitude] values as integers.
     """
-    latVal = int(round(latitude * FINAL_LAT_PRECISION_))
+    latVal = int(math.floor(latitude * FINAL_LAT_PRECISION_))
     latVal += LATITUDE_MAX_ * FINAL_LAT_PRECISION_
     if latVal < 0:
         latVal = 0
     elif latVal >= 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_:
         latVal = 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_ - 1
 
-    lngVal = int(round(longitude * FINAL_LNG_PRECISION_))
+    lngVal = int(math.floor(longitude * FINAL_LNG_PRECISION_))
     lngVal += LONGITUDE_MAX_ * FINAL_LNG_PRECISION_
     if lngVal < 0:
         # Python's % operator differs from other languages in that it returns
@@ -256,6 +257,7 @@ def locationToIntegers(latitude, longitude):
     elif lngVal >= 2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_:
         lngVal = lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_)
     return (latVal, lngVal)
+
 
 def encode(latitude, longitude, codeLength=PAIR_CODE_LENGTH_):
     """
@@ -274,13 +276,9 @@ def encode(latitude, longitude, codeLength=PAIR_CODE_LENGTH_):
       codeLength: The number of significant digits in the output code, not
           including any separator characters.
     """
-    if codeLength < MIN_DIGIT_COUNT_ or (codeLength < PAIR_CODE_LENGTH_ and
-                                         codeLength % 2 == 1):
-        raise ValueError('Invalid Open Location Code length - ' +
-                         str(codeLength))
-    codeLength = min(codeLength, MAX_DIGIT_COUNT_)
     (latInt, lngInt) = locationToIntegers(latitude, longitude)
     return encodeIntegers(latInt, lngInt, codeLength)
+
 
 def encodeIntegers(latVal, lngVal, codeLength):
     """
@@ -289,6 +287,11 @@ def encodeIntegers(latVal, lngVal, codeLength):
     This function is exposed for testing purposes and should not be called
     directly.
     """
+    if codeLength < MIN_DIGIT_COUNT_ or (codeLength < PAIR_CODE_LENGTH_ and
+                                         codeLength % 2 == 1):
+        raise ValueError('Invalid Open Location Code length - ' +
+                         str(codeLength))
+    codeLength = min(codeLength, MAX_DIGIT_COUNT_)
     # Initialise the code string.
     code = ''
 


### PR DESCRIPTION
See issues https://github.com/google/open-location-code/issues/674 and https://github.com/google/open-location-code/issues/717.

This corrects the implementation to use floor when converting from degrees to the integer values, and adds tests for the conversion of degrees to integer, encoding from integers, and adds tolerance to the degrees encoding (due to floating point precision).