### PR TITLE
Release java artifact to sonatype

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -2,12 +2,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <groupId>com.google.openlocationcode</groupId>
   <artifactId>openlocationcode</artifactId>
   <version>1.0.4</version>
@@ -15,6 +9,14 @@
 
   <name>Open Location Code</name>
   <url>https://github.com/google/open-location-code</url>
+  <description>This is the Java implementation of Open Location Code </description>
+
+  <scm>
+    <connection>scm:git:${project.scm.url}.git</connection>
+    <developerConnection>scm:git:${project.scm.url}.git</developerConnection>
+    <url>https://github.com/google/open-location-code</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <licenses>
     <license>
@@ -22,6 +24,13 @@
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
+
+
+  <developers>
+    <developer>
+      <name>Jiri Semecky</name>
+    </developer>
+  </developers>
 
   <dependencies>
     <dependency>
@@ -96,14 +105,13 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.9.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
       <plugin>
@@ -180,14 +188,4 @@
     </plugins>
   </reporting>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.google.openlocationcode</groupId>
   <artifactId>openlocationcode</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <packaging>jar</packaging>
 
   <name>Open Location Code</name>


### PR DESCRIPTION
I think it is a good idea to release a minor of this. A few small improvements were done.

The sonatype procedure was changed in the mean time. This pull request will make it work again. It is nowadays enough to leave it to their new maven plugin 'central-publishing-maven-plugin'.

Only the credentials need to be upgraded iirc. See 
https://central.sonatype.org/publish/publish-portal-maven/#usage