### PR TITLE
Migrate js/closure to bzlmod with rules_closure 0.15.0

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,5 +1,4 @@
 # Set options for Bazelisk, a wrapper for Bazel.
 
 # Set the version of Bazel to use.
-# TODO: #642 -- Update once the JS bazelbuild/rules_closure supports bazel modules.
 USE_BAZEL_VERSION=7.4.1

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "1.0",
 )
 
-# bazel-skylib required by #@io_bazel_rules_closure.
+# bazel-skylib required by rules_closure.
 # https://github.com/bazelbuild/bazel-skylib
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
@@ -11,3 +11,6 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 # https://github.com/google/googletest
 bazel_dep(name = "googletest", version = "1.15.2")
 
+# rules_closure for js/closure tests.
+# https://github.com/bazelbuild/rules_closure
+bazel_dep(name = "rules_closure", version = "0.15.0")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,19 +1,4 @@
 # Workspace configuration for Bazel build tools.
+# Note: Most dependencies are now managed via MODULE.bazel (bzlmod).
 
-# TODO: #642 -- Remove once io_bazel_rules_closure supports Bazel module configuration.
 workspace(name = "openlocationcode")
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "io_bazel_rules_closure",
-    integrity = "sha256-EvEWnr54L4Yx/LjagaoSuhkviVKHW0oejyDEn8bhAiM=",
-    strip_prefix = "rules_closure-0.14.0",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.14.0.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/0.14.0.tar.gz",
-    ],
-)
-load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
-rules_closure_dependencies()
-rules_closure_toolchains()

--- a/js/closure/BUILD
+++ b/js/closure/BUILD
@@ -1,5 +1,5 @@
 # Load the necessary Closure rules
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library", "closure_js_test")
+load("@rules_closure//closure:defs.bzl", "closure_js_library", "closure_js_test")
 
 # Define the Closure library for Open Location Code
 closure_js_library(
@@ -9,6 +9,8 @@ closure_js_library(
 )
 
 # Define the Closure test for Open Location Code
+# Note: rules_closure 0.15.0 removed dependency on com_google_javascript_closure_library
+# and now includes a forked test suite in the rules_closure package itself.
 closure_js_test(
     name = "openlocationcode_test",
     timeout = "short",
@@ -19,10 +21,10 @@ closure_js_test(
     entry_points = ["goog:openlocationcode_test"],
     deps = [
         ":openlocationcode_lib",
-        "@com_google_javascript_closure_library//closure/goog/net:eventtype",
-        "@com_google_javascript_closure_library//closure/goog/net:xhrio",
-        "@com_google_javascript_closure_library//closure/goog/testing:asserts",
-        "@com_google_javascript_closure_library//closure/goog/testing:asynctestcase",
-        "@com_google_javascript_closure_library//closure/goog/testing:testsuite",
+        "@rules_closure//closure/library/net:eventtype",
+        "@rules_closure//closure/library/net:xhrio",
+        "@rules_closure//closure/testing:asserts",
+        "@rules_closure//closure/testing:asynctestcase",
+        "@rules_closure//closure/testing:testsuite",
     ],
 )


### PR DESCRIPTION
Fixes #642

The Basel closure fix upstream is now used in our project here. 

Please approve for CI, I don't have all these tools running locally.