### PR TITLE
go: Eliminate memory allocations and reduce Decode time by 26%

### DIFF
--- a/go/olc.go
+++ b/go/olc.go
@@ -188,18 +188,19 @@ func upper(b byte) byte {
 // The code is truncated to the first 15 digits, as Decode won't use more,
 // to avoid underflow errors.
 func StripCode(code string) string {
-	code = strings.Map(
-		func(r rune) rune {
-			if r == Separator || r == Padding {
-				return -1
-			}
-			return rune(upper(byte(r)))
-		},
-		code)
-	if len(code) > maxCodeLen {
-		return code[:maxCodeLen]
+	result := make([]byte, maxCodeLen)
+	pos := 0
+	for _, r := range code {
+		if r == Separator || r == Padding {
+			continue
+		}
+		result[pos] = upper(byte(r))
+		pos++
+		if pos >= maxCodeLen {
+			break
+		}
 	}
-	return code
+	return string(result[:pos])
 }
 
 // Because the OLC codes are an area, they can't start at 180 degrees, because they would then have something > 180 as their upper bound.


### PR DESCRIPTION
Use handwritten version of strings.Map logic. This avoids having to dynamically allocate and resize the byte slice, and allows the compiler to fully remove memory allocations from the operation. As a result, the time spent in StripCode is almost completely removed.

Before:

```sh
$ go test . -bench=Decode -benchtime=10s
...
goos: linux
goarch: amd64
pkg: github.com/google/open-location-code/go
cpu: AMD Ryzen Threadripper 3970X 32-Core Processor 
BenchmarkDecode-64    	32295574	       337.7 ns/op	      24 B/op	       1 allocs/op
```

After:

```sh
$ go test . -bench=Decode -benchtime=10s
...
goos: linux
goarch: amd64
pkg: github.com/google/open-location-code/go
cpu: AMD Ryzen Threadripper 3970X 32-Core Processor 
BenchmarkDecode-64    	48074581	       248.5 ns/op	       0 B/op	       0 allocs/op
```

CPU Profiles:

Before:

<img width="1428" height="3184" alt="before" src="https://github.com/user-attachments/assets/99fa3516-c6ba-430e-85d4-13b10e84483b" />

After:

<img width="2091" height="1777" alt="after" src="https://github.com/user-attachments/assets/fdca6886-e715-4633-8d2d-ec9f5945f5ad" />
