### PR TITLE
rust: Add rust tests to bazelisk

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -3,3 +3,5 @@
 # Set the version of Bazel to use.
 # TODO: #642 -- Update once the JS bazelbuild/rules_closure supports bazel modules.
 USE_BAZEL_VERSION=7.4.1
+# Use lld linker for rust since gold is deprecated and has known bugs.
+build --linkopt=-fuse-ld=lld

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,1 @@
+# Required for rules_rust configuration.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,3 +11,26 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 # https://github.com/google/googletest
 bazel_dep(name = "googletest", version = "1.15.2")
 
+bazel_dep(name = "rules_rust", version = "0.58.0")
+
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(
+    edition = "2024",
+    versions = ["1.85.0"],
+)
+use_repo(rust, "rust_toolchains")
+
+register_toolchains("@rust_toolchains//:all")
+
+crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
+crate.from_cargo(
+    name = "crates",
+    cargo_lockfile = "//rust:Cargo.lock",
+    manifests = ["//rust:Cargo.toml"],
+)
+crate.annotation(
+    crate = "open-location-code",
+    rustc_flags = ["-Zunstable-options"],
+)
+use_repo(crate, "crates")
+

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,8 @@ bazel_dep(name = "googletest", version = "1.15.2")
 
 bazel_dep(name = "rules_rust", version = "0.58.0")
 
+bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")
+
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
@@ -33,4 +35,3 @@ crate.annotation(
     rustc_flags = ["-Zunstable-options"],
 )
 use_repo(crate, "crates")
-

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,8 +21,4 @@ crate.from_cargo(
     cargo_lockfile = "//rust:Cargo.lock",
     manifests = ["//rust:Cargo.toml"],
 )
-crate.annotation(
-    crate = "open-location-code",
-    rustc_flags = ["-Zunstable-options"],
-)
 use_repo(crate, "crates")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,15 +15,6 @@ bazel_dep(name = "rules_rust", version = "0.58.0")
 
 bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")
 
-rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
-rust.toolchain(
-    edition = "2024",
-    versions = ["1.85.0"],
-)
-use_repo(rust, "rust_toolchains")
-
-register_toolchains("@rust_toolchains//:all")
-
 crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
 crate.from_cargo(
     name = "crates",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,13 +5,13 @@ module(
 
 # bazel-skylib required by #@io_bazel_rules_closure.
 # https://github.com/bazelbuild/bazel-skylib
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
 
 # googletest required by c/BUILD.
 # https://github.com/google/googletest
 bazel_dep(name = "googletest", version = "1.15.2")
 
-bazel_dep(name = "rules_rust", version = "0.58.0")
+bazel_dep(name = "rules_rust", version = "0.69.0")
 
 bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")
 

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -1,14 +1,19 @@
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
 
 rust_library(
     name = "open_location_code",
-    srcs = glob(["src/**/*.rs"]),
-    edition = "2024",
-    visibility = ["//visibility:public"],
+    srcs = [
+        "src/lib.rs",
+        "src/codearea.rs",
+        "src/consts.rs",
+        "src/interface.rs",
+        "src/private.rs",
+    ],
     deps = all_crate_deps(
         normal = True,
     ),
+    visibility = ["//visibility:private"],
 )
 
 rust_test(
@@ -18,15 +23,12 @@ rust_test(
         "tests/all_test.rs",
         "tests/csv_reader.rs",
     ],
-    data = ["//test_data:test_data"],
-    edition = "2024",
-    proc_macro_deps = all_crate_deps(
-        proc_macro_dev = True,
-    ),
+    data = ["//test_data"],
     deps = [
         ":open_location_code",
     ] + all_crate_deps(
         normal = True,
         normal_dev = True,
     ),
+    visibility = ["//visibility:private"],
 )

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -1,0 +1,32 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite")
+load("@crates//:defs.bzl", "all_crate_deps")
+
+rust_library(
+    name = "open_location_code",
+    srcs = glob(["src/**/*.rs"]),
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = all_crate_deps(
+        normal = True,
+    ),
+)
+
+rust_test(
+    name = "all_test",
+    size = "small",
+    srcs = [
+        "tests/all_test.rs",
+        "tests/csv_reader.rs",
+    ],
+    data = ["//test_data:test_data"],
+    edition = "2024",
+    proc_macro_deps = all_crate_deps(
+        proc_macro_dev = True,
+    ),
+    deps = [
+        ":open_location_code",
+    ] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ),
+)

--- a/rust/tests/all_test.rs
+++ b/rust/tests/all_test.rs
@@ -19,7 +19,7 @@ use rand::random_range;
 #[test]
 fn is_valid_test() {
     let mut tested = 0;
-    for line in CSVReader::new("validityTests.csv") {
+    for line in CSVReader::new("validityTests.csv").unwrap() {
         let cols: Vec<&str> = line.split(',').collect();
         let code = cols[0];
         let _valid = cols[1] == "true";
@@ -38,7 +38,7 @@ fn is_valid_test() {
 #[test]
 fn decode_test() {
     let mut tested = 0;
-    for line in CSVReader::new("decoding.csv") {
+    for line in CSVReader::new("decoding.csv").unwrap() {
         let cols: Vec<&str> = line.split(',').collect();
         let code = cols[0];
         let len = cols[1].parse::<usize>().unwrap();
@@ -65,7 +65,7 @@ fn encode_test() {
     let mut errors = 0;
     // Allow a small proportion of errors due to floating point.
     let allowed_error_rate = 0.05;
-    for line in CSVReader::new("encoding.csv") {
+    for line in CSVReader::new("encoding.csv").unwrap() {
         if line.chars().count() == 0 {
             continue;
         }
@@ -97,7 +97,7 @@ fn encode_test() {
 #[test]
 fn point_to_integers_test() {
     let mut tested = 0;
-    for line in CSVReader::new("encoding.csv") {
+    for line in CSVReader::new("encoding.csv").unwrap() {
         if line.chars().count() == 0 {
             continue;
         }
@@ -131,7 +131,7 @@ fn point_to_integers_test() {
 #[test]
 fn encode_integers_test() {
     let mut tested = 0;
-    for line in CSVReader::new("encoding.csv") {
+    for line in CSVReader::new("encoding.csv").unwrap() {
         if line.chars().count() == 0 {
             continue;
         }
@@ -158,7 +158,7 @@ fn encode_integers_test() {
 #[test]
 fn shorten_recovery_test() {
     let mut tested = 0;
-    for line in CSVReader::new("shortCodeTests.csv") {
+    for line in CSVReader::new("shortCodeTests.csv").unwrap() {
         let cols: Vec<&str> = line.split(',').collect();
         let full_code = cols[0];
         let lat = cols[1].parse::<f64>().unwrap();

--- a/rust/tests/csv_reader.rs
+++ b/rust/tests/csv_reader.rs
@@ -1,20 +1,43 @@
 use std::env::current_dir;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Lines};
+use std::io::{BufRead, BufReader, Lines, Error};
+use std::io::ErrorKind::InvalidInput;
+use std::path::PathBuf;
 
 pub struct CSVReader {
     iter: Lines<BufReader<File>>,
 }
 
 impl CSVReader {
-    pub fn new(csv_name: &str) -> CSVReader {
+    pub fn new(csv_name: &str) -> Result<CSVReader, Error> {
         // Assumes we're called from <open-location-code root>/rust
-        let project_root = current_dir().unwrap();
-        let olc_root = project_root.parent().unwrap();
+        let project_root = current_dir()?;
+
+        let olc_root: PathBuf = match project_root.file_name().and_then(|n| n.to_str()) {
+            Some("rust") => project_root
+                .parent()
+                .map(|p| p.to_path_buf())
+                .ok_or_else(|| Error::new(InvalidInput, "Could not find project root parent")),
+            Some("_main") => Ok(project_root.clone()),
+            _ => {
+                return Err(Error::new(InvalidInput, format!(
+                    "Expected current dir to end with 'rust' or '_main', got {:?}",
+                    project_root
+                )));
+            }
+        }?;
         let csv_path = olc_root.join("test_data").join(csv_name);
-        CSVReader {
-            iter: BufReader::new(File::open(csv_path).unwrap()).lines(),
-        }
+
+        let file = File::open(&csv_path).map_err(|e| {
+            Error::new(e.kind(), format!(
+                "Failed to open CSV file at {:?}: {} (Current dir: {:?})",
+                csv_path, e, project_root
+            ))
+        })?;
+
+        Ok(CSVReader {
+            iter: BufReader::new(file).lines(),
+        })
     }
 }
 


### PR DESCRIPTION
Previously running `bazelisk test ...:all` did not run Rust tests. This change configures crate in MODULE.bazel.

Add rust/BUILD with minimal library and test configuration. I've copied the private visibility rules that other language's BUILD files use, let me know if we don't want that.

I modified the CSVReader used in testing to:
1. Detect if it's being run with "cargo test" or "bazelisk test", and use the appropriate test data directory.
2. Return helpful errors if it is unable to find the test data CSV.

I'm not super confident in how idiomatic this rust code is, main bit was to help me while debugging why bazelisk test wasn't working.