### PR TITLE
cpp: Fix clang-tidy compile warning for kPairPrecisionInverse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ MODULE.bazel.lock
 **/target/
 # Ignore intelliJ auto generated dir
 **/.idea/
+# Ignore CLion/bazel auto generated dir
+**/.clwb/
 # Ignore iml extensions files
 **/*.iml
 # Ignore visual studio auto generated dir

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -32,5 +32,5 @@ Code must be formatted using `clang-format`, and this will be checked in the
 tests. You can format your code using the script:
 
 ```
-sh clang_check.sh
+bash clang_check.sh
 ```

--- a/cpp/openlocationcode.cc
+++ b/cpp/openlocationcode.cc
@@ -1,8 +1,7 @@
 #include "openlocationcode.h"
 
-#include <float.h>
-
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <cstdint>
 
@@ -29,7 +28,7 @@ const size_t kInitialExponent = floor(log(360) / log(kEncodingBase));
 const double kGridSizeDegrees =
     1 / pow(kEncodingBase, kPairCodeLength / 2 - (kInitialExponent + 1));
 // Inverse (1/) of the precision of the final pair digits in degrees. (20^3)
-const size_t kPairPrecisionInverse = 8000;
+const int64_t kPairPrecisionInverse = 8000;
 // Inverse (1/) of the precision of the final grid digits in degrees.
 // (Latitude and longitude are different.)
 const int64_t kGridLatPrecisionInverse =


### PR DESCRIPTION
It looks like kPairPrecisionInverse was incorrectly marked size_t (which is unsigned) instead of int64_t, like kGridLatPrecisionInverse. This caused an implicit conversion from unsigned to signed, which clang_tidy warned about on compilation.

I've changed it to int64_t, which does resolve the warning.

Fix warning about using deprecated float.h in favor of cfloat.

Update cpp/README.md to instruct to use bash and not sh, as clang_check.sh cannot be run by sh (it returns a parsing error).

Add **/.clwb/ dir to .gitignore. CLion uses it for storing project metadata for linking to bazel.